### PR TITLE
Added and registered pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,14 @@ dependencies = [
     "pytest-xdist"
 ]
 [tool.pytest.ini_options]
+addopts = "-ra --strict-markers"
 markers = [
     "local: tests that run against the local backend (no infrastructure)",
     "kubernetes: tests that run steps on Kubernetes (requires dev stack)",
     "argo_workflows: tests that deploy to Argo Workflows (requires dev stack + Argo)",
+]
+filterwarnings = [
+    "error::pytest.PytestUnknownMarkWarning"
 ]
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ dependencies = [
     "pytest",
     "pytest-xdist"
 ]
-
+[tool.pytest.ini_options]
+markers = [
+    "local: tests that run against the local backend (no infrastructure)",
+    "kubernetes: tests that run steps on Kubernetes (requires dev stack)",
+    "argo_workflows: tests that deploy to Argo Workflows (requires dev stack + Argo)",
+]
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
+++ b/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
@@ -15,7 +15,7 @@ ROOT = os.path.dirname(__file__)
 def test_tags(test_id):
     return ["argo_workflows_tests", "conditional_step_tests", test_id]
 
-
+@pytest.mark.argo_workflows
 @pytest.mark.parametrize(
     "filename",
     [
@@ -58,7 +58,7 @@ def test_conditional_flows(filename, test_tags, test_id):
             # Clean up deployed flows.
             deployed_flow.delete()
 
-
+@pytest.mark.argo_workflows
 @pytest.mark.parametrize(
     "filename",
     [

--- a/src/metaflow_qa_tests/argo_workflows/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/conftest.py
@@ -1,3 +1,8 @@
 import pytest
+from pathlib import Path
 
-pytestmark=pytest.mark.argo_workflows
+def pytest_collection_modifyitems(config, items):
+    curr_dir = Path(__file__).parent
+    for item in items:
+        if curr_dir in item.path.parents and not item.get_closest_marker("argo_workflows"):
+            item.add_marker(pytest.mark.argo_workflows)

--- a/src/metaflow_qa_tests/argo_workflows/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark=pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
+++ b/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
@@ -13,7 +13,7 @@ ROOT = os.path.dirname(__file__)
 def test_tags(test_id):
     return ["argo_workflows_tests", "deploy_time_triggers_tests", test_id]
 
-
+@pytest.mark.argo_workflows
 def test_successful_trigger_deployments(test_tags):
     # "filename, expected_trigger",
     filename_and_trigger = [
@@ -47,7 +47,7 @@ def test_successful_trigger_deployments(test_tags):
         for deployer in deployers:
             deployer.delete()
 
-
+@pytest.mark.argo_workflows
 def test_successful_trigger_on_finish_deployments(test_tags):
     # "filename, expected_trigger"
     filename_and_trigger = [
@@ -87,7 +87,7 @@ def test_successful_trigger_on_finish_deployments(test_tags):
         for deployer in deployers:
             deployer.delete()
 
-
+@pytest.mark.argo_workflows
 def test_expected_failing_trigger_deployments(test_tags):
     # "filename",
     filenames = [

--- a/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
+++ b/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
@@ -19,7 +19,7 @@ def test_tags(test_id):
 
 # TODO: Add coverage for dashed params and double-quoted strings!
 
-
+@pytest.mark.argo_workflows
 def test_events(test_tags, test_id):
     try:
         deployed_event_flow = (
@@ -60,7 +60,7 @@ def test_events(test_tags, test_id):
         deployed_trigger_flow.delete()
         deployed_event_flow.delete()
 
-
+@pytest.mark.argo_workflows
 def test_cron(test_tags, test_id):
     try:
         deployed_cron_flow = (
@@ -79,7 +79,7 @@ def test_cron(test_tags, test_id):
     finally:
         deployed_cron_flow.delete()
 
-
+@pytest.mark.argo_workflows
 def test_base_params(test_tags):
     try:
         deployed_flow = (

--- a/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
+++ b/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
@@ -10,7 +10,7 @@ FLOWS_ROOT = os.path.join(os.path.dirname(__file__), "..", "flows")
 def test_tags(test_id):
     return ["argo_workflows_tests", test_id]
 
-
+@pytest.mark.argo_workflows
 def test_argo_helloflow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")
@@ -26,7 +26,7 @@ def test_argo_helloflow(test_tags, test_id):
         # clean up.
         deployed_flow.delete()
 
-
+@pytest.mark.argo_workflows
 def test_argo_conda_flow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"), environment="conda"
@@ -42,7 +42,7 @@ def test_argo_conda_flow(test_tags, test_id):
         # clean up.
         deployed_flow.delete()
 
-
+@pytest.mark.argo_workflows
 def test_argo_pypi_flow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "pypitest.py"), environment="pypi"
@@ -58,7 +58,7 @@ def test_argo_pypi_flow(test_tags, test_id):
         # clean up.
         deployed_flow.delete()
 
-
+@pytest.mark.argo_workflows
 def test_argo_notifications(test_tags):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")

--- a/src/metaflow_qa_tests/basic/conftest.py
+++ b/src/metaflow_qa_tests/basic/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark=pytest.mark.local

--- a/src/metaflow_qa_tests/basic/conftest.py
+++ b/src/metaflow_qa_tests/basic/conftest.py
@@ -1,3 +1,8 @@
 import pytest
+from pathlib import Path
 
-pytestmark=pytest.mark.local
+def pytest_collection_modifyitems(config, items):
+    curr_dir = Path(__file__).parent
+    for item in items:
+        if curr_dir in item.path.parents and not item.get_closest_marker("local"):
+            item.add_marker(pytest.mark.local)

--- a/src/metaflow_qa_tests/basic/test_basic.py
+++ b/src/metaflow_qa_tests/basic/test_basic.py
@@ -9,7 +9,7 @@ FLOWS_ROOT = os.path.join(os.path.dirname(__file__), "..", "flows")
 def test_tags(test_id):
     return ["basic_tests", test_id]
 
-
+@pytest.mark.local
 def test_helloflow(test_tags):
     result = Runner(flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")).run(
         tags=test_tags
@@ -17,7 +17,7 @@ def test_helloflow(test_tags):
 
     assert result.run.finished
 
-
+@pytest.mark.local
 def test_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"), environment="conda"
@@ -25,7 +25,7 @@ def test_conda_flow(test_tags):
 
     assert result.run.finished
 
-
+@pytest.mark.local
 def test_pypi_flow(test_tags):
     # Should default to fast-env
     result = Runner(

--- a/src/metaflow_qa_tests/flows/pypitest.py
+++ b/src/metaflow_qa_tests/flows/pypitest.py
@@ -1,7 +1,7 @@
 from metaflow import FlowSpec, step, pypi_base
 
 
-@pypi_base(packages={"pandas": "1.5.2"}, python="3.11")
+@pypi_base(packages={"pandas": "1.5.2", "numpy": "<2.0.0"}, python="3.11")
 class PyPIFlow(FlowSpec):
     @step
     def start(self):

--- a/src/metaflow_qa_tests/kubernetes/conftest.py
+++ b/src/metaflow_qa_tests/kubernetes/conftest.py
@@ -1,3 +1,8 @@
 import pytest
+from pathlib import Path
 
-pytestmark=pytest.mark.kubernetes
+def pytest_collection_modifyitems(config, items):
+    curr_dir = Path(__file__).parent
+    for item in items:
+        if curr_dir in item.path.parents and not item.get_closest_marker("kubernetes"):
+            item.add_marker(pytest.mark.kubernetes)

--- a/src/metaflow_qa_tests/kubernetes/conftest.py
+++ b/src/metaflow_qa_tests/kubernetes/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark=pytest.mark.kubernetes

--- a/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
+++ b/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
@@ -9,7 +9,7 @@ FLOWS_ROOT = os.path.join(os.path.dirname(__file__), "..", "flows")
 def test_tags(test_id):
     return ["kubernetes_tests", test_id]
 
-
+@pytest.mark.kubernetes
 def test_kubernetes_helloflow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py"), decospecs=["kubernetes"]
@@ -17,7 +17,7 @@ def test_kubernetes_helloflow(test_tags):
 
     assert result.run.finished
 
-
+@pytest.mark.kubernetes
 def test_kubernetes_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"),
@@ -27,7 +27,7 @@ def test_kubernetes_conda_flow(test_tags):
 
     assert result.run.finished
 
-
+@pytest.mark.kubernetes
 def test_kubernetes_pypi_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "pypitest.py"),


### PR DESCRIPTION

Fixes #2 

### This PR includes:
* Registered `local`, `kubernetes`, and `argo_workflows` markers to the `[tool.pytest.ini_options]` section in `pyproject.toml`.
* Added `@pytest.mark.local` marker in `basic/test_basic.py`.
* Added `@pytest.mark.kubernetes` marker to all test cases in `kubernetes/test_kubernetes.py`.
* Added `@pytest.mark.argo_workflows` marker to all tests under `argo_workflows/`  folder.
* Added `conftest.py` files in each subdirectory with `pytest_collection_modifyitems` hook function as a fallback function for adding markers.

### Verification
I have verified that all the commad works fine. And no `PytestUnknownMarkWarning` warnings are thrown.
* `pytest -m local --pyargs metaflow_qa_tests`  and `pytest -m local` Runs exactly 3 tests.
* `pytest -m kubernetes --pyargs metaflow_qa_tests` and `pytest -m kubernetes`  Runs exactly 3 tests.
* `pytest -m argo_workflows --pyargs metaflow_qa_tests` and `pytest -m argo_workflows` Runs all Argo tests.
* `pytest -m "not argo_workflows" --pyargs metaflow_qa_tests` and `pytest -m "not argo_workflows"`  Runs everything except Argo tests (6 tests).

AI Usage
* I used Gemini to debug a failure in `test_pypi_flow`. Added `numpy<2.0.0` in the `pypi_base` decorator to solve the error `ValueError: numpy.dtype size changed`