### PR TITLE
#2 Add pytest markers for backend-selective test execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,11 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers"
+markers = [
+    "local: tests that run against the local backend (no infrastructure)",
+    "kubernetes: tests that run steps on Kubernetes (requires dev stack)",
+    "argo_workflows: tests that deploy to Argo Workflows (requires dev stack + Argo)",
+]

--- a/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
+++ b/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
@@ -7,6 +7,7 @@ from ..utils import (
 import io
 import os
 
+pytestmark = pytest.mark.argo_workflows
 
 ROOT = os.path.dirname(__file__)
 

--- a/src/metaflow_qa_tests/argo_workflows/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
+++ b/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
@@ -4,6 +4,8 @@ from contextlib import redirect_stdout
 import io
 import os
 
+pytestmark = pytest.mark.argo_workflows
+
 ROOT = os.path.dirname(__file__)
 
 # TODO: Test the actual triggered behaviour as well. Omitted for now, as the deployment should be enough of a verification for this functionality.

--- a/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
+++ b/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
@@ -9,6 +9,8 @@ from ..utils import (
 )
 import os
 
+pytestmark = pytest.mark.argo_workflows
+
 ROOTPATH = os.path.dirname(__file__)
 
 

--- a/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
+++ b/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
@@ -3,6 +3,8 @@ from metaflow import Deployer
 from .utils import wait_for_run, wait_for_run_to_finish
 import os
 
+pytestmark = pytest.mark.argo_workflows
+
 FLOWS_ROOT = os.path.join(os.path.dirname(__file__), "..", "flows")
 
 

--- a/src/metaflow_qa_tests/basic/conftest.py
+++ b/src/metaflow_qa_tests/basic/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark = pytest.mark.local

--- a/src/metaflow_qa_tests/basic/test_basic.py
+++ b/src/metaflow_qa_tests/basic/test_basic.py
@@ -10,6 +10,7 @@ def test_tags(test_id):
     return ["basic_tests", test_id]
 
 
+@pytest.mark.local
 def test_helloflow(test_tags):
     result = Runner(flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")).run(
         tags=test_tags
@@ -18,6 +19,7 @@ def test_helloflow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.local
 def test_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"), environment="conda"
@@ -26,6 +28,7 @@ def test_conda_flow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.local
 def test_pypi_flow(test_tags):
     # Should default to fast-env
     result = Runner(

--- a/src/metaflow_qa_tests/kubernetes/conftest.py
+++ b/src/metaflow_qa_tests/kubernetes/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark = pytest.mark.kubernetes

--- a/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
+++ b/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
@@ -10,6 +10,7 @@ def test_tags(test_id):
     return ["kubernetes_tests", test_id]
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_helloflow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py"), decospecs=["kubernetes"]
@@ -18,6 +19,7 @@ def test_kubernetes_helloflow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"),
@@ -28,6 +30,7 @@ def test_kubernetes_conda_flow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_pypi_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "pypitest.py"),


### PR DESCRIPTION
**## Summary**
Adds pytest markers to enable selective test execution by backend (local, kubernetes, argo_workflows), resolving PytestUnknownMarkWarning warnings and allowing CI to target specific backends.

**Fixes #2**
**## Changes**
- Registered markers in `pyproject.toml` via `[tool.pytest.ini_options]` 
  with `--strict-markers` to fail loudly on unregistered marks
- Applied `@pytest.mark.local` to tests in `basic/test_basic.py`
- Applied `@pytest.mark.kubernetes` to tests in `kubernetes/test_kubernetes.py`
- Applied `@pytest.mark.argo_workflows` to all 4 argo test files via `pytestmark`
- Added `conftest.py` in each subdirectory as a safety net for future tests

No `PytestUnknownMarkWarning` warnings observed.

**## Verification**

**pytest -m local             # 3 tests**
<img width="1919" height="357" alt="image" src="https://github.com/user-attachments/assets/4738ad3b-f658-4609-86f3-b6e8c3d922aa" />

**pytest -m kubernetes        # 3 tests**
<img width="1919" height="367" alt="image" src="https://github.com/user-attachments/assets/d8a13ea1-eec3-436e-83de-32eb2ce6c1e4" />

**pytest -m argo_workflows    # 31 tests**
<img width="1919" height="856" alt="image" src="https://github.com/user-attachments/assets/8d1b2321-137f-433c-9398-2aec7ce4585a" />

**pytest -m "not argo_workflows"  # 6 tests**
<img width="1919" height="405" alt="image" src="https://github.com/user-attachments/assets/18bbec94-87bd-44ab-9853-005bef76cd0f" />


## Notes
`--strict-markers` is added to `addopts` so unregistered marks fail 
loudly rather than silently passing, making future mark typos immediately 
visible.