### PR TITLE
feat: add pytest markers for backend-selective test execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,12 @@ dependencies = [
     "pytest-xdist"
 ]
 
+[tool.pytest.ini_options]
+markers = [
+    "local: tests that run against the local backend (no infrastructure)",
+    "kubernetes: tests that run steps on Kubernetes (requires dev stack)",
+    "argo_workflows: tests that deploy to Argo Workflows (requires dev stack + Argo)",
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/metaflow_qa_tests/argo_workflows/conditional_tests/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/conditional_tests/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "argo_workflows" by default.
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
+++ b/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
@@ -16,6 +16,7 @@ def test_tags(test_id):
     return ["argo_workflows_tests", "conditional_step_tests", test_id]
 
 
+@pytest.mark.argo_workflows
 @pytest.mark.parametrize(
     "filename",
     [
@@ -59,6 +60,7 @@ def test_conditional_flows(filename, test_tags, test_id):
             deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 @pytest.mark.parametrize(
     "filename",
     [

--- a/src/metaflow_qa_tests/argo_workflows/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory (and subdirectories) are "argo_workflows" by default.
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "argo_workflows" by default.
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
+++ b/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
@@ -14,6 +14,7 @@ def test_tags(test_id):
     return ["argo_workflows_tests", "deploy_time_triggers_tests", test_id]
 
 
+@pytest.mark.argo_workflows
 def test_successful_trigger_deployments(test_tags):
     # "filename, expected_trigger",
     filename_and_trigger = [
@@ -48,6 +49,7 @@ def test_successful_trigger_deployments(test_tags):
             deployer.delete()
 
 
+@pytest.mark.argo_workflows
 def test_successful_trigger_on_finish_deployments(test_tags):
     # "filename, expected_trigger"
     filename_and_trigger = [
@@ -88,6 +90,7 @@ def test_successful_trigger_on_finish_deployments(test_tags):
             deployer.delete()
 
 
+@pytest.mark.argo_workflows
 def test_expected_failing_trigger_deployments(test_tags):
     # "filename",
     filenames = [

--- a/src/metaflow_qa_tests/argo_workflows/parameter_tests/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/parameter_tests/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "argo_workflows" by default.
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
+++ b/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
@@ -20,6 +20,7 @@ def test_tags(test_id):
 # TODO: Add coverage for dashed params and double-quoted strings!
 
 
+@pytest.mark.argo_workflows
 def test_events(test_tags, test_id):
     try:
         deployed_event_flow = (
@@ -61,6 +62,7 @@ def test_events(test_tags, test_id):
         deployed_event_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_cron(test_tags, test_id):
     try:
         deployed_cron_flow = (
@@ -80,6 +82,7 @@ def test_cron(test_tags, test_id):
         deployed_cron_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_base_params(test_tags):
     try:
         deployed_flow = (

--- a/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
+++ b/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
@@ -11,6 +11,7 @@ def test_tags(test_id):
     return ["argo_workflows_tests", test_id]
 
 
+@pytest.mark.argo_workflows
 def test_argo_helloflow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")
@@ -27,6 +28,7 @@ def test_argo_helloflow(test_tags, test_id):
         deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_argo_conda_flow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"), environment="conda"
@@ -43,6 +45,7 @@ def test_argo_conda_flow(test_tags, test_id):
         deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_argo_pypi_flow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "pypitest.py"), environment="pypi"
@@ -59,6 +62,7 @@ def test_argo_pypi_flow(test_tags, test_id):
         deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_argo_notifications(test_tags):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")

--- a/src/metaflow_qa_tests/basic/conftest.py
+++ b/src/metaflow_qa_tests/basic/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "local" by default.
+pytestmark = pytest.mark.local

--- a/src/metaflow_qa_tests/basic/test_basic.py
+++ b/src/metaflow_qa_tests/basic/test_basic.py
@@ -10,6 +10,7 @@ def test_tags(test_id):
     return ["basic_tests", test_id]
 
 
+@pytest.mark.local
 def test_helloflow(test_tags):
     result = Runner(flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")).run(
         tags=test_tags
@@ -18,6 +19,7 @@ def test_helloflow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.local
 def test_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"), environment="conda"
@@ -26,6 +28,7 @@ def test_conda_flow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.local
 def test_pypi_flow(test_tags):
     # Should default to fast-env
     result = Runner(

--- a/src/metaflow_qa_tests/kubernetes/conftest.py
+++ b/src/metaflow_qa_tests/kubernetes/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "kubernetes" by default.
+pytestmark = pytest.mark.kubernetes

--- a/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
+++ b/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
@@ -10,6 +10,7 @@ def test_tags(test_id):
     return ["kubernetes_tests", test_id]
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_helloflow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py"), decospecs=["kubernetes"]
@@ -18,6 +19,7 @@ def test_kubernetes_helloflow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"),
@@ -28,6 +30,7 @@ def test_kubernetes_conda_flow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_pypi_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "pypitest.py"),


### PR DESCRIPTION
Fixes:
* #2 

## Testing
1. Local only:
`pytest -m local --pyargs metaflow_qa_tests --collect-only -q`
2. Kubernetes only:
`pytest -m kubernetes --pyargs metaflow_qa_tests --collect-only -q`
3. Argo only:
`pytest -m argo_workflows --pyargs metaflow_qa_tests --collect-only -q`
4. Everything except Argo:
`pytest -m "not argo_workflows" --pyargs metaflow_qa_tests --collect-only -q`
5. confirmed no unknown marker warnings:
`pytest --pyargs metaflow_qa_tests --collect-only -q -W error::pytest.PytestUnknownMarkWarning`

## Acceptance Criteria (MVP)

- [x] pyproject.toml has [tool.pytest.ini_options] with registered markers
- [x] Every test has a backend marker (directly or via pytestmark)
- [x] pytest -m local runs exactly the 3 basic tests
- [x] pytest -m kubernetes runs exactly the 3 kubernetes tests
- [x] pytest -m argo_workflows runs all argo tests
- [x] No PytestUnknownMarkWarning warnings