### PR TITLE
feat: add tox.ini with backend-specific environments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,12 @@ dependencies = [
     "pytest-xdist"
 ]
 
+[tool.pytest.ini_options]
+markers = [
+    "local: tests that run against the local backend (no infrastructure)",
+    "kubernetes: tests that run steps on Kubernetes (requires dev stack)",
+    "argo_workflows: tests that deploy to Argo Workflows (requires dev stack + Argo)",
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/metaflow_qa_tests/argo_workflows/conditional_tests/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/conditional_tests/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "argo_workflows" by default.
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
+++ b/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
@@ -16,6 +16,7 @@ def test_tags(test_id):
     return ["argo_workflows_tests", "conditional_step_tests", test_id]
 
 
+@pytest.mark.argo_workflows
 @pytest.mark.parametrize(
     "filename",
     [
@@ -59,6 +60,7 @@ def test_conditional_flows(filename, test_tags, test_id):
             deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 @pytest.mark.parametrize(
     "filename",
     [

--- a/src/metaflow_qa_tests/argo_workflows/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory (and subdirectories) are "argo_workflows" by default.
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "argo_workflows" by default.
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
+++ b/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
@@ -14,6 +14,7 @@ def test_tags(test_id):
     return ["argo_workflows_tests", "deploy_time_triggers_tests", test_id]
 
 
+@pytest.mark.argo_workflows
 def test_successful_trigger_deployments(test_tags):
     # "filename, expected_trigger",
     filename_and_trigger = [
@@ -48,6 +49,7 @@ def test_successful_trigger_deployments(test_tags):
             deployer.delete()
 
 
+@pytest.mark.argo_workflows
 def test_successful_trigger_on_finish_deployments(test_tags):
     # "filename, expected_trigger"
     filename_and_trigger = [
@@ -88,6 +90,7 @@ def test_successful_trigger_on_finish_deployments(test_tags):
             deployer.delete()
 
 
+@pytest.mark.argo_workflows
 def test_expected_failing_trigger_deployments(test_tags):
     # "filename",
     filenames = [

--- a/src/metaflow_qa_tests/argo_workflows/parameter_tests/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/parameter_tests/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "argo_workflows" by default.
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
+++ b/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
@@ -20,6 +20,7 @@ def test_tags(test_id):
 # TODO: Add coverage for dashed params and double-quoted strings!
 
 
+@pytest.mark.argo_workflows
 def test_events(test_tags, test_id):
     try:
         deployed_event_flow = (
@@ -61,6 +62,7 @@ def test_events(test_tags, test_id):
         deployed_event_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_cron(test_tags, test_id):
     try:
         deployed_cron_flow = (
@@ -80,6 +82,7 @@ def test_cron(test_tags, test_id):
         deployed_cron_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_base_params(test_tags):
     try:
         deployed_flow = (

--- a/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
+++ b/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
@@ -11,6 +11,7 @@ def test_tags(test_id):
     return ["argo_workflows_tests", test_id]
 
 
+@pytest.mark.argo_workflows
 def test_argo_helloflow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")
@@ -27,6 +28,7 @@ def test_argo_helloflow(test_tags, test_id):
         deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_argo_conda_flow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"), environment="conda"
@@ -43,6 +45,7 @@ def test_argo_conda_flow(test_tags, test_id):
         deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_argo_pypi_flow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "pypitest.py"), environment="pypi"
@@ -59,6 +62,7 @@ def test_argo_pypi_flow(test_tags, test_id):
         deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_argo_notifications(test_tags):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")

--- a/src/metaflow_qa_tests/basic/conftest.py
+++ b/src/metaflow_qa_tests/basic/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "local" by default.
+pytestmark = pytest.mark.local

--- a/src/metaflow_qa_tests/basic/test_basic.py
+++ b/src/metaflow_qa_tests/basic/test_basic.py
@@ -10,6 +10,7 @@ def test_tags(test_id):
     return ["basic_tests", test_id]
 
 
+@pytest.mark.local
 def test_helloflow(test_tags):
     result = Runner(flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")).run(
         tags=test_tags
@@ -18,6 +19,7 @@ def test_helloflow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.local
 def test_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"), environment="conda"
@@ -26,6 +28,7 @@ def test_conda_flow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.local
 def test_pypi_flow(test_tags):
     # Should default to fast-env
     result = Runner(

--- a/src/metaflow_qa_tests/kubernetes/conftest.py
+++ b/src/metaflow_qa_tests/kubernetes/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "kubernetes" by default.
+pytestmark = pytest.mark.kubernetes

--- a/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
+++ b/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
@@ -10,6 +10,7 @@ def test_tags(test_id):
     return ["kubernetes_tests", test_id]
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_helloflow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py"), decospecs=["kubernetes"]
@@ -18,6 +19,7 @@ def test_kubernetes_helloflow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"),
@@ -28,6 +30,7 @@ def test_kubernetes_conda_flow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_pypi_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "pypitest.py"),

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,47 @@
+[tox]
+envlist = local, kubernetes, argo, all
+
+[testenv]
+# Install the package (and its deps from pyproject.toml) into each tox env.
+deps = .
+# Pass through environment variables needed by metaflow-dev shell/K8s/Argo.
+passenv =
+    # Metaflow configuration
+    METAFLOW_HOME
+    METAFLOW_PROFILE
+    METAFLOW_SERVICE_URL
+    METAFLOW_SERVICE_INTERNAL_URL
+    METAFLOW_DEFAULT_DATASTORE
+    METAFLOW_DATASTORE_SYSROOT_S3
+    # Kubernetes
+    METAFLOW_KUBERNETES_NAMESPACE
+    METAFLOW_KUBERNETES_SECRETS
+    # AWS/MinIO (used by dev stack)
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
+    AWS_ENDPOINT_URL_S3
+    AWS_CONFIG_FILE
+    AWS_*
+    # System
+    HOME
+    USER
+
+[testenv:local]
+description = Run tests against the local backend (no infrastructure needed)
+commands =
+    pytest -m local --pyargs metaflow_qa_tests -v {posargs}
+
+[testenv:kubernetes]
+description = Run tests that execute steps on Kubernetes (requires dev stack)
+commands =
+    pytest -m kubernetes --pyargs metaflow_qa_tests -v {posargs}
+
+[testenv:argo]
+description = Run tests that deploy to Argo Workflows (requires dev stack + Argo)
+commands =
+    pytest -m argo_workflows --pyargs metaflow_qa_tests -v {posargs}
+
+[testenv:all]
+description = Run the full test suite across all backends
+commands =
+    pytest --pyargs metaflow_qa_tests -v {posargs}


### PR DESCRIPTION
### Fixes:
* #3

### Based On:
* #12 

### Testing:
1. Verify [tox -e local] works:
`tox -e local -- --collect-only -q`

2. Test {posargs} passthrough with -k:
`tox -e local -- -k test_helloflow --collect-only -q`

3. Check the other envs collect correctly:
`tox -e kubernetes -- --collect-only -q`
`tox -e argo -- --collect-only -q`
`tox -e all -- --collect-only -q`

### Acceptance Criteria (MVP)

- [x] tox -e local runs local tests from a clean checkout
- [x] tox -e kubernetes runs K8s tests (inside metaflow-dev shell)
- [x] tox -e argo runs Argo tests (inside metaflow-dev shell)
- [x] passenv covers all dev stack environment variables
- [x] tox -e local -- -k test_helloflow passes extra args through to pytest