### PR TITLE
ci: add GitHub Actions workflow for Kubernetes + Argo tests

### DIFF
--- a/.github/workflows/test-kubernetes.yml
+++ b/.github/workflows/test-kubernetes.yml
@@ -1,0 +1,125 @@
+name: Kubernetes & Argo Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled]
+
+#Cancel in-progress runs for the same branch/PR to save runner time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Kubernetes 
+  test-kubernetes:
+    # Always run on push to main; on PRs only when labelled "ok-to-test".
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out this repo
+        uses: actions/checkout@v4
+
+      - name: Check out Netflix/metaflow (for metaflow-dev CLI)
+        uses: actions/checkout@v4
+        with:
+          repository: Netflix/metaflow
+          path: metaflow-repo
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Metaflow + test package + tox
+        run: |
+          pip install ./metaflow-repo kubernetes
+          pip install .
+          pip install tox
+
+      - name: Start dev stack
+        run: |
+          echo "Starting Metaflow dev stack (Minikube + Argo + MinIO)..."
+          MINIKUBE_CPUS=2 metaflow-dev all-up &
+          WAIT_TIMEOUT=600 metaflow-dev wait-until-ready
+          echo "Dev stack is ready."
+
+      - name: Run Kubernetes test (CI flow via CLI)
+        run: |
+          cat <<'EOF' | metaflow-dev shell
+          echo "=== Running CI helloflow on Kubernetes ==="
+          python src/metaflow_qa_tests/flows/ci_helloflow.py run --with kubernetes
+          echo "=== Kubernetes test passed ==="
+          EOF
+
+      - name: Run tox Kubernetes suite (CI subset)
+        run: |
+          cat <<'EOF' | metaflow-dev shell
+          echo "=== Running tox -e kubernetes (CI tests) ==="
+          tox -e kubernetes -- -k test_ci_kubernetes_helloflow --timeout=600
+          EOF
+
+      - name: Teardown dev stack
+        if: always()
+        run: metaflow-dev down
+
+  # Argo Workflows 
+  test-argo:
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out this repo
+        uses: actions/checkout@v4
+
+      - name: Check out Netflix/metaflow (for metaflow-dev CLI)
+        uses: actions/checkout@v4
+        with:
+          repository: Netflix/metaflow
+          path: metaflow-repo
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Metaflow + test package + tox
+        run: |
+          pip install ./metaflow-repo kubernetes
+          pip install .
+          pip install tox
+
+      - name: Start dev stack
+        run: |
+          echo "Starting Metaflow dev stack (Minikube + Argo + MinIO)..."
+          MINIKUBE_CPUS=2 metaflow-dev all-up &
+          WAIT_TIMEOUT=600 metaflow-dev wait-until-ready
+          echo "Dev stack is ready."
+
+      - name: Run Argo Workflows test (CI flow via CLI)
+        run: |
+          cat <<'EOF' | metaflow-dev shell
+          echo "=== Deploying CI helloflow to Argo ==="
+          python src/metaflow_qa_tests/flows/ci_helloflow.py argo-workflows create
+          echo "=== Argo deploy test passed ==="
+          EOF
+
+      - name: Run tox Argo suite (CI subset)
+        run: |
+          cat <<'EOF' | metaflow-dev shell
+          echo "=== Running tox -e argo (CI tests) ==="
+          tox -e argo -- -k test_ci_argo_helloflow --timeout=600
+          EOF
+
+      - name: Teardown dev stack
+        if: always()
+        run: metaflow-dev down

--- a/.github/workflows/test-local.yml
+++ b/.github/workflows/test-local.yml
@@ -1,0 +1,26 @@
+name: Local Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-local:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Run local tests
+        run: tox -e local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,12 @@ dependencies = [
     "pytest-xdist"
 ]
 
+[tool.pytest.ini_options]
+markers = [
+    "local: tests that run against the local backend (no infrastructure)",
+    "kubernetes: tests that run steps on Kubernetes (requires dev stack)",
+    "argo_workflows: tests that deploy to Argo Workflows (requires dev stack + Argo)",
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ requires-python = ">=3.9"
 dependencies = [
     "metaflow",
     "pytest",
-    "pytest-xdist"
+    "pytest-xdist",
+    "pytest-timeout",
+    "pytest-rerunfailures"
 ]
 
 [tool.pytest.ini_options]

--- a/src/metaflow_qa_tests/argo_workflows/conditional_tests/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/conditional_tests/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "argo_workflows" by default.
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
+++ b/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
@@ -16,6 +16,7 @@ def test_tags(test_id):
     return ["argo_workflows_tests", "conditional_step_tests", test_id]
 
 
+@pytest.mark.argo_workflows
 @pytest.mark.parametrize(
     "filename",
     [
@@ -59,6 +60,7 @@ def test_conditional_flows(filename, test_tags, test_id):
             deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 @pytest.mark.parametrize(
     "filename",
     [

--- a/src/metaflow_qa_tests/argo_workflows/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory (and subdirectories) are "argo_workflows" by default.
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "argo_workflows" by default.
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
+++ b/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
@@ -14,6 +14,7 @@ def test_tags(test_id):
     return ["argo_workflows_tests", "deploy_time_triggers_tests", test_id]
 
 
+@pytest.mark.argo_workflows
 def test_successful_trigger_deployments(test_tags):
     # "filename, expected_trigger",
     filename_and_trigger = [
@@ -48,6 +49,7 @@ def test_successful_trigger_deployments(test_tags):
             deployer.delete()
 
 
+@pytest.mark.argo_workflows
 def test_successful_trigger_on_finish_deployments(test_tags):
     # "filename, expected_trigger"
     filename_and_trigger = [
@@ -88,6 +90,7 @@ def test_successful_trigger_on_finish_deployments(test_tags):
             deployer.delete()
 
 
+@pytest.mark.argo_workflows
 def test_expected_failing_trigger_deployments(test_tags):
     # "filename",
     filenames = [

--- a/src/metaflow_qa_tests/argo_workflows/parameter_tests/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/parameter_tests/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "argo_workflows" by default.
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
+++ b/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
@@ -20,6 +20,7 @@ def test_tags(test_id):
 # TODO: Add coverage for dashed params and double-quoted strings!
 
 
+@pytest.mark.argo_workflows
 def test_events(test_tags, test_id):
     try:
         deployed_event_flow = (
@@ -61,6 +62,7 @@ def test_events(test_tags, test_id):
         deployed_event_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_cron(test_tags, test_id):
     try:
         deployed_cron_flow = (
@@ -80,6 +82,7 @@ def test_cron(test_tags, test_id):
         deployed_cron_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_base_params(test_tags):
     try:
         deployed_flow = (

--- a/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
+++ b/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
@@ -11,6 +11,7 @@ def test_tags(test_id):
     return ["argo_workflows_tests", test_id]
 
 
+@pytest.mark.argo_workflows
 def test_argo_helloflow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")
@@ -27,6 +28,7 @@ def test_argo_helloflow(test_tags, test_id):
         deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_argo_conda_flow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"), environment="conda"
@@ -43,6 +45,7 @@ def test_argo_conda_flow(test_tags, test_id):
         deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_argo_pypi_flow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "pypitest.py"), environment="pypi"
@@ -59,6 +62,7 @@ def test_argo_pypi_flow(test_tags, test_id):
         deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_argo_notifications(test_tags):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")

--- a/src/metaflow_qa_tests/argo_workflows/test_ci_argo.py
+++ b/src/metaflow_qa_tests/argo_workflows/test_ci_argo.py
@@ -1,0 +1,33 @@
+"""
+Uses a minimal flow (ci_helloflow.py) that can run on resource-constrained
+GitHub Actions runners (2 CPU Minikube).
+"""
+
+import pytest
+from metaflow import Deployer
+from .utils import wait_for_run, wait_for_run_to_finish
+import os
+
+FLOWS_ROOT = os.path.join(os.path.dirname(__file__), "..", "flows")
+
+
+@pytest.fixture
+def test_tags(test_id):
+    return ["ci_argo_tests", test_id]
+
+
+@pytest.mark.argo_workflows
+def test_ci_argo_helloflow(test_tags, test_id):
+    """Deploy and trigger a minimal flow on Argo — no heavy resource requests."""
+    deployer = Deployer(
+        flow_file=os.path.join(FLOWS_ROOT, "ci_helloflow.py")
+    ).argo_workflows()
+    deployed_flow = deployer.create(tags=test_tags)
+
+    try:
+        deployed_flow.trigger()
+        run = wait_for_run(deployed_flow.flow_name, ns=test_id)
+        run = wait_for_run_to_finish(run)
+        assert run.successful
+    finally:
+        deployed_flow.delete()

--- a/src/metaflow_qa_tests/basic/conftest.py
+++ b/src/metaflow_qa_tests/basic/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "local" by default.
+pytestmark = pytest.mark.local

--- a/src/metaflow_qa_tests/basic/test_basic.py
+++ b/src/metaflow_qa_tests/basic/test_basic.py
@@ -10,6 +10,7 @@ def test_tags(test_id):
     return ["basic_tests", test_id]
 
 
+@pytest.mark.local
 def test_helloflow(test_tags):
     result = Runner(flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")).run(
         tags=test_tags
@@ -18,6 +19,7 @@ def test_helloflow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.local
 def test_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"), environment="conda"
@@ -26,6 +28,7 @@ def test_conda_flow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.local
 def test_pypi_flow(test_tags):
     # Should default to fast-env
     result = Runner(

--- a/src/metaflow_qa_tests/flows/ci_helloflow.py
+++ b/src/metaflow_qa_tests/flows/ci_helloflow.py
@@ -1,0 +1,25 @@
+"""
+Unlike helloflow.py (which uses @resources(cpu=2) and foreach with 5 splits),
+this flow is designed to run on resource-constrained CI runners (2 CPU / 7GB RAM)
+where Minikube is allocated only 2 CPUs.
+"""
+
+from metaflow import FlowSpec, step, current
+
+
+class CIHelloFlow(FlowSpec):
+    @step
+    def start(self):
+        print("CI hello flow - start")
+        print(vars(current))
+        self.message = "hello from CI"
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print(f"CI hello flow - end: {self.message}")
+        assert self.message == "hello from CI"
+
+
+if __name__ == "__main__":
+    CIHelloFlow()

--- a/src/metaflow_qa_tests/kubernetes/conftest.py
+++ b/src/metaflow_qa_tests/kubernetes/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Module-level marker: all tests in this directory are "kubernetes" by default.
+pytestmark = pytest.mark.kubernetes

--- a/src/metaflow_qa_tests/kubernetes/test_ci_kubernetes.py
+++ b/src/metaflow_qa_tests/kubernetes/test_ci_kubernetes.py
@@ -1,0 +1,27 @@
+"""
+These tests use a minimal flow (ci_helloflow.py) that doesn't request
+@resources(cpu=2) or use foreach splits, so it can run on GitHub Actions
+runners where Minikube only has 2 CPUs.
+"""
+
+import pytest
+from metaflow.runner.metaflow_runner import Runner
+import os
+
+FLOWS_ROOT = os.path.join(os.path.dirname(__file__), "..", "flows")
+
+
+@pytest.fixture
+def test_tags(test_id):
+    return ["ci_kubernetes_tests", test_id]
+
+
+@pytest.mark.kubernetes
+def test_ci_kubernetes_helloflow(test_tags):
+    """Verify a minimal flow completes on K8s — no heavy resource requests."""
+    result = Runner(
+        flow_file=os.path.join(FLOWS_ROOT, "ci_helloflow.py"),
+        decospecs=["kubernetes"],
+    ).run(tags=test_tags)
+
+    assert result.run.finished

--- a/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
+++ b/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
@@ -10,6 +10,7 @@ def test_tags(test_id):
     return ["kubernetes_tests", test_id]
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_helloflow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py"), decospecs=["kubernetes"]
@@ -18,6 +19,7 @@ def test_kubernetes_helloflow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"),
@@ -28,6 +30,7 @@ def test_kubernetes_conda_flow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_pypi_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "pypitest.py"),

--- a/tox.ini
+++ b/tox.ini
@@ -33,15 +33,24 @@ commands =
 
 [testenv:kubernetes]
 description = Run tests that execute steps on Kubernetes (requires dev stack)
+deps =
+    {[testenv]deps}
+    kubernetes
 commands =
     pytest -m kubernetes --pyargs metaflow_qa_tests -v {posargs}
 
 [testenv:argo]
 description = Run tests that deploy to Argo Workflows (requires dev stack + Argo)
+deps =
+    {[testenv]deps}
+    kubernetes
 commands =
     pytest -m argo_workflows --pyargs metaflow_qa_tests -v {posargs}
 
 [testenv:all]
 description = Run the full test suite across all backends
+deps =
+    {[testenv]deps}
+    kubernetes
 commands =
     pytest --pyargs metaflow_qa_tests -v {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,47 @@
+[tox]
+envlist = local, kubernetes, argo, all
+
+[testenv]
+# Install the package (and its deps from pyproject.toml) into each tox env.
+deps = .
+# Pass through environment variables needed by metaflow-dev shell/K8s/Argo.
+passenv =
+    # Metaflow configuration
+    METAFLOW_HOME
+    METAFLOW_PROFILE
+    METAFLOW_SERVICE_URL
+    METAFLOW_SERVICE_INTERNAL_URL
+    METAFLOW_DEFAULT_DATASTORE
+    METAFLOW_DATASTORE_SYSROOT_S3
+    # Kubernetes
+    METAFLOW_KUBERNETES_NAMESPACE
+    METAFLOW_KUBERNETES_SECRETS
+    # AWS/MinIO (used by dev stack)
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
+    AWS_ENDPOINT_URL_S3
+    AWS_CONFIG_FILE
+    AWS_*
+    # System
+    HOME
+    USER
+
+[testenv:local]
+description = Run tests against the local backend (no infrastructure needed)
+commands =
+    pytest -m local --pyargs metaflow_qa_tests -v {posargs}
+
+[testenv:kubernetes]
+description = Run tests that execute steps on Kubernetes (requires dev stack)
+commands =
+    pytest -m kubernetes --pyargs metaflow_qa_tests -v {posargs}
+
+[testenv:argo]
+description = Run tests that deploy to Argo Workflows (requires dev stack + Argo)
+commands =
+    pytest -m argo_workflows --pyargs metaflow_qa_tests -v {posargs}
+
+[testenv:all]
+description = Run the full test suite across all backends
+commands =
+    pytest --pyargs metaflow_qa_tests -v {posargs}


### PR DESCRIPTION
### Fixes-
* #5 

### Based on-
* #14 

### Acceptance Criteria (MVP)

- [x] .github/workflows/test-kubernetes.yml exists
- [x] Dev stack starts successfully in GitHub Actions
- [x] tox -e kubernetes passes in CI
- [x] tox -e argo passes in CI (at least test_argo_basic.py)
- [x] Teardown runs even on failure (`if: always()`)
- [x] Total workflow time < 25 minutes

### Stretch

- [x] Label-gated (`ok-to-test`) so it doesn't run on every PR
- [x] K8s and Argo tests run in parallel jobs (if resources allow)