### PR TITLE
feat: add tox.ini with backend-specific environments and complete passenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,56 @@
+[tox]
+envlist = local, kubernetes, argo
+
+[testenv]
+usedevelop = true
+passenv =
+    # Core Metaflow config
+    METAFLOW_HOME
+    METAFLOW_PROFILE
+    METAFLOW_DEFAULT_METADATA
+    METAFLOW_SERVICE_URL
+    METAFLOW_SERVICE_INTERNAL_URL
+    METAFLOW_UI_URL
+    # Datastore / S3 / MinIO
+    METAFLOW_DEFAULT_DATASTORE
+    METAFLOW_DATASTORE_SYSROOT_S3
+    AWS_CONFIG_FILE
+    AWS_SHARED_CREDENTIALS_FILE
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
+    AWS_ENDPOINT_URL_S3
+    # Kubernetes
+    METAFLOW_KUBERNETES_NAMESPACE
+    METAFLOW_KUBERNETES_SECRETS
+    METAFLOW_KUBERNETES_JOBSET_ENABLED
+    METAFLOW_KUBERNETES_CONDA_ARCH
+    # Argo Events
+    METAFLOW_ARGO_EVENTS_EVENT
+    METAFLOW_ARGO_EVENTS_EVENT_BUS
+    METAFLOW_ARGO_EVENTS_EVENT_SOURCE
+    METAFLOW_ARGO_EVENTS_INTERNAL_WEBHOOK_URL
+    METAFLOW_ARGO_EVENTS_SERVICE_ACCOUNT
+    METAFLOW_ARGO_EVENTS_WEBHOOK_AUTH
+    METAFLOW_ARGO_EVENTS_WEBHOOK_URL
+    # System
+    HOME
+    USER
+    KUBECONFIG
+
+[testenv:local]
+commands = pytest -m local --pyargs metaflow_qa_tests -v {posargs}
+
+[testenv:kubernetes]
+deps = kubernetes
+commands = pytest -m kubernetes --pyargs metaflow_qa_tests -v {posargs}
+
+[testenv:argo]
+deps = kubernetes
+commands = pytest -m argo_workflows --pyargs metaflow_qa_tests -v {posargs}
+
+[testenv:all]
+deps = kubernetes
+commands =
+    pytest -m local --pyargs metaflow_qa_tests -v {posargs}
+    pytest -m kubernetes --pyargs metaflow_qa_tests -v {posargs}
+    pytest -m argo_workflows --pyargs metaflow_qa_tests -v {posargs}


### PR DESCRIPTION
Fixes #3
Depends on #2

## Summary
Adds tox.ini so running tests requires no tribal knowledge. `tox -e local` just works from a clean checkout.

## Acceptance Criteria
- [x] `tox -e local` runs 3 local tests
- [x] `tox -e kubernetes` runs K8s tests inside metaflow-dev shell
- [x] `tox -e argo` runs Argo tests inside metaflow-dev shell
- [x] `passenv` covers all dev stack variables
- [x] `tox -e local -- -k test_helloflow` works via {posargs}

## Open Design Questions Answered

**tox -e all — sequential:**`tox -e all` runs local, kubernetes, and argo as 3 separate pytest calls one by one. Reason: utils.py wait_for_run mutates global namespace(). If all backends run in one pytest call, a kubernetes test and argo test could match each other's runs. Sequential calls give each backend its own isolated session.

`all` is NOT in envlist — so plain `tox` runs local, kubernetes, argo once each. `tox -e all` is a separate explicit shortcut for when you want everything in one command.

**--test-id — left to conftest:**conftest.py already generates a random UUID per run automatically.Adding a fixed --test-id like local001 in tox would cause collision if two CI runs happen at the same time.

**{posargs} — at end of every command:**`tox -e local -- -k test_helloflow` passes `-k test_helloflow` directly to pytest. Works in all 4 environments.

## Changes
- Added tox.ini with local, kubernetes, argo, all environments
- usedevelop = true installs package from pyproject.toml in every env
- kubernetes dep only in kubernetes and argo envs — confirmed by running full test suite locally, all argo/kubernetes tests         failed with "Could not import module 'kubernetes'" without it
- Sequential commands in tox -e all
- No --test-id in tox
- {posargs} at end of every command

## Verification

Tested with markers from #2 applied locally.

- `tox -e local -- --collect-only` — 3/37 collected ✅
<img width="1918" height="602" alt="image" src="https://github.com/user-attachments/assets/db0f922e-6c93-4cc3-bb0f-aa0c55fe4e38" />


****Inside metaflow-dev shell**** 

(confirmed via `echo $METAFLOW_HOME` and `echo $METAFLOW_PROFILE`):
<img width="1105" height="72" alt="image" src="https://github.com/user-attachments/assets/03181d9f-124b-4209-8a18-78c93ec98be8" />

- `tox -e kubernetes -- --collect-only` — 3/37 collected ✅
<img width="1460" height="562" alt="image" src="https://github.com/user-attachments/assets/ef29344d-8e71-447a-a75d-600e1c510049" />

- `tox -e argo -- --collect-only` — 31/37 collected ✅
<img width="1919" height="949" alt="image" src="https://github.com/user-attachments/assets/8fdac2c1-0c8d-45b6-9b61-a2b6700896c4" />
