### PR TITLE
Added pytests for backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,12 @@ dependencies = [
     "pytest-xdist"
 ]
 
+[tool.pytest.ini_options]
+markers = [
+    "local: tests that run against the local backend (no infrastructure)",
+    "kubernetes: tests that run steps on Kubernetes (requires dev stack)",
+    "argo_workflows: tests that deploy to Argo Workflows (requires dev stack + Argo)",
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
+++ b/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
@@ -36,6 +36,7 @@ def test_tags(test_id):
         "conditionalSkipFlow5.py",
     ],
 )
+@pytest.mark.argo_workflows
 def test_conditional_flows(filename, test_tags, test_id):
     deployed_flow = None
     try:
@@ -70,6 +71,7 @@ def test_conditional_flows(filename, test_tags, test_id):
         "nestedRecursiveConditional3.py",
     ],
 )
+@pytest.mark.argo_workflows
 def test_failing_conditional_flows(filename, test_tags, test_id):
     deployed_flow = None
     try:

--- a/src/metaflow_qa_tests/argo_workflows/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from pathlib import Path
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        path = Path(str(item.fspath))
+        if "argo_workflows" in path.parts:
+            item.add_marker(pytest.mark.argo_workflows)

--- a/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
+++ b/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
@@ -13,7 +13,7 @@ ROOT = os.path.dirname(__file__)
 def test_tags(test_id):
     return ["argo_workflows_tests", "deploy_time_triggers_tests", test_id]
 
-
+@pytest.mark.argo_workflows
 def test_successful_trigger_deployments(test_tags):
     # "filename, expected_trigger",
     filename_and_trigger = [
@@ -47,7 +47,7 @@ def test_successful_trigger_deployments(test_tags):
         for deployer in deployers:
             deployer.delete()
 
-
+@pytest.mark.argo_workflows
 def test_successful_trigger_on_finish_deployments(test_tags):
     # "filename, expected_trigger"
     filename_and_trigger = [
@@ -87,7 +87,7 @@ def test_successful_trigger_on_finish_deployments(test_tags):
         for deployer in deployers:
             deployer.delete()
 
-
+@pytest.mark.argo_workflows
 def test_expected_failing_trigger_deployments(test_tags):
     # "filename",
     filenames = [

--- a/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
+++ b/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
@@ -19,7 +19,7 @@ def test_tags(test_id):
 
 # TODO: Add coverage for dashed params and double-quoted strings!
 
-
+@pytest.mark.argo_workflows
 def test_events(test_tags, test_id):
     try:
         deployed_event_flow = (
@@ -60,7 +60,7 @@ def test_events(test_tags, test_id):
         deployed_trigger_flow.delete()
         deployed_event_flow.delete()
 
-
+@pytest.mark.argo_workflows
 def test_cron(test_tags, test_id):
     try:
         deployed_cron_flow = (
@@ -79,7 +79,7 @@ def test_cron(test_tags, test_id):
     finally:
         deployed_cron_flow.delete()
 
-
+@pytest.mark.argo_workflows
 def test_base_params(test_tags):
     try:
         deployed_flow = (

--- a/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
+++ b/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
@@ -10,7 +10,7 @@ FLOWS_ROOT = os.path.join(os.path.dirname(__file__), "..", "flows")
 def test_tags(test_id):
     return ["argo_workflows_tests", test_id]
 
-
+@pytest.mark.argo_workflows
 def test_argo_helloflow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")
@@ -26,7 +26,7 @@ def test_argo_helloflow(test_tags, test_id):
         # clean up.
         deployed_flow.delete()
 
-
+@pytest.mark.argo_workflows
 def test_argo_conda_flow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"), environment="conda"
@@ -42,7 +42,7 @@ def test_argo_conda_flow(test_tags, test_id):
         # clean up.
         deployed_flow.delete()
 
-
+@pytest.mark.argo_workflows
 def test_argo_pypi_flow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "pypitest.py"), environment="pypi"
@@ -58,7 +58,7 @@ def test_argo_pypi_flow(test_tags, test_id):
         # clean up.
         deployed_flow.delete()
 
-
+@pytest.mark.argo_workflows
 def test_argo_notifications(test_tags):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")

--- a/src/metaflow_qa_tests/basic/conftest.py
+++ b/src/metaflow_qa_tests/basic/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from pathlib import Path
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        path = Path(str(item.fspath))
+        if "basic" in path.parts:
+            item.add_marker(pytest.mark.local)

--- a/src/metaflow_qa_tests/basic/test_basic.py
+++ b/src/metaflow_qa_tests/basic/test_basic.py
@@ -9,7 +9,7 @@ FLOWS_ROOT = os.path.join(os.path.dirname(__file__), "..", "flows")
 def test_tags(test_id):
     return ["basic_tests", test_id]
 
-
+@pytest.mark.local
 def test_helloflow(test_tags):
     result = Runner(flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")).run(
         tags=test_tags
@@ -17,7 +17,7 @@ def test_helloflow(test_tags):
 
     assert result.run.finished
 
-
+@pytest.mark.local
 def test_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"), environment="conda"
@@ -25,7 +25,7 @@ def test_conda_flow(test_tags):
 
     assert result.run.finished
 
-
+@pytest.mark.local
 def test_pypi_flow(test_tags):
     # Should default to fast-env
     result = Runner(

--- a/src/metaflow_qa_tests/flows/pypitest.py
+++ b/src/metaflow_qa_tests/flows/pypitest.py
@@ -1,7 +1,7 @@
 from metaflow import FlowSpec, step, pypi_base
 
 
-@pypi_base(packages={"pandas": "1.5.2"}, python="3.11")
+@pypi_base(packages={"pandas": "1.5.2", "numpy": "<2.0.0"}, python="3.11")
 class PyPIFlow(FlowSpec):
     @step
     def start(self):

--- a/src/metaflow_qa_tests/kubernetes/conftest.py
+++ b/src/metaflow_qa_tests/kubernetes/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from pathlib import Path
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        path = Path(str(item.fspath))
+        if "kubernetes" in path.parts:
+            item.add_marker(pytest.mark.kubernetes)

--- a/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
+++ b/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
@@ -9,7 +9,7 @@ FLOWS_ROOT = os.path.join(os.path.dirname(__file__), "..", "flows")
 def test_tags(test_id):
     return ["kubernetes_tests", test_id]
 
-
+@pytest.mark.kubernetes
 def test_kubernetes_helloflow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py"), decospecs=["kubernetes"]
@@ -17,7 +17,7 @@ def test_kubernetes_helloflow(test_tags):
 
     assert result.run.finished
 
-
+@pytest.mark.kubernetes
 def test_kubernetes_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"),
@@ -27,7 +27,7 @@ def test_kubernetes_conda_flow(test_tags):
 
     assert result.run.finished
 
-
+@pytest.mark.kubernetes
 def test_kubernetes_pypi_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "pypitest.py"),


### PR DESCRIPTION
Fixes:  #2 
In this PR I solve the issue 1a mentioned that is "Add pytest markers for backend-selective test execution"

Tasks are currently run by specifying directory paths.

I have introduced pytest markers for each of the 3 backend:
-basic(local)
-kubernetes
-argo_workflows

I have also updated the pyproject to note the markers to avoid any warnings.
For ```conftest.py``` my approach is different than that given in the issue as ```pytestmark``` is not able to mark or propagate to the tests. I have tested it by unmarking few issues while testing and this assumption made by the issue didn't seem to work.
So I have introduced an alternative approach where I used  ```pytest_collection_modifyitems``` so it adds as the tests appear.

An alternative way I may suggest will be to add ```pytestmark = pytest.mark.(backend)``` at the top of the files. This way specifically adding the tags to each test won't be necessary(though I understand it's to make it much easier to understand later) and also eliminates the need for ```conftest.py```

All the MVP tasks have been performed successfully. I have added images for verification:
<img width="1481" height="387" alt="Screenshot 2026-03-06 at 3 28 58 AM" src="https://github.com/user-attachments/assets/870033eb-cb92-48d5-a4d3-3120c457be6e" />
<img width="1481" height="485" alt="Screenshot 2026-03-06 at 3 31 22 AM" src="https://github.com/user-attachments/assets/2787d76d-fff4-4697-b474-936e69142006" />
<img width="1481" height="810" alt="Screenshot 2026-03-06 at 3 31 36 AM" src="https://github.com/user-attachments/assets/39d808ef-0b52-4ea2-81d0-3e90f63c9c06" />
<img width="1481" height="314" alt="Screenshot 2026-03-06 at 3 31 42 AM" src="https://github.com/user-attachments/assets/ce717831-887e-40d5-a970-78c4841cdd97" />