### PR TITLE
ci: add GitHub Actions workflow for local tests

### DIFF
--- a/.github/workflows/test-local.yml
+++ b/.github/workflows/test-local.yml
@@ -1,0 +1,38 @@
+name: Local Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-local:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Run local tests
+        run: tox -e local


### PR DESCRIPTION
Fixes #4
Depends on #2, #3

## Summary
Adds first CI to this repo. Every push and PR to main now automatically runs local tests across Python 3.10-3.13 on ubuntu-latest.

## Changes
- Added .github/workflows/test-local.yml
- Triggers on push and PR to main
- Matrix across Python 3.10-3.13 on ubuntu-latest only
- fail-fast: false — all Python versions run independently so 
  we see the full failure picture, not just the first failure
- pip cache keyed on pyproject.toml hash to speed up repeated runs
- Uses tox -e local (not raw pytest) — depends on #3

## Why ubuntu-latest only
macOS adds CI cost with no benefit for local backend tests. 

## Why correct action versions
Used actions/checkout@v4 and actions/setup-python@v5 current stable versions. 

## Verification (Ubuntu/WSL)
tox -e local -- --collect-only     → 3/37 collected ✅
tox -e local -- -k test_helloflow  → 1/37 collected ✅

