### PR TITLE
chore(issue 2): add pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,10 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+markers = [
+    "local: tests that run against the local backend (no infrastructure)",
+    "kubernetes: tests that run steps on Kubernetes (requires dev stack)",
+    "argo_workflows: tests that deploy to Argo Workflows (requires dev stack + Argo)",
+]

--- a/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
+++ b/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
@@ -16,6 +16,7 @@ def test_tags(test_id):
     return ["argo_workflows_tests", "conditional_step_tests", test_id]
 
 
+@pytest.mark.argo_workflows
 @pytest.mark.parametrize(
     "filename",
     [
@@ -59,6 +60,7 @@ def test_conditional_flows(filename, test_tags, test_id):
             deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 @pytest.mark.parametrize(
     "filename",
     [

--- a/src/metaflow_qa_tests/argo_workflows/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
+++ b/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
@@ -14,6 +14,7 @@ def test_tags(test_id):
     return ["argo_workflows_tests", "deploy_time_triggers_tests", test_id]
 
 
+@pytest.mark.argo_workflows
 def test_successful_trigger_deployments(test_tags):
     # "filename, expected_trigger",
     filename_and_trigger = [
@@ -48,6 +49,7 @@ def test_successful_trigger_deployments(test_tags):
             deployer.delete()
 
 
+@pytest.mark.argo_workflows
 def test_successful_trigger_on_finish_deployments(test_tags):
     # "filename, expected_trigger"
     filename_and_trigger = [
@@ -88,6 +90,7 @@ def test_successful_trigger_on_finish_deployments(test_tags):
             deployer.delete()
 
 
+@pytest.mark.argo_workflows
 def test_expected_failing_trigger_deployments(test_tags):
     # "filename",
     filenames = [

--- a/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
+++ b/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
@@ -20,6 +20,7 @@ def test_tags(test_id):
 # TODO: Add coverage for dashed params and double-quoted strings!
 
 
+@pytest.mark.argo_workflows
 def test_events(test_tags, test_id):
     try:
         deployed_event_flow = (
@@ -61,6 +62,7 @@ def test_events(test_tags, test_id):
         deployed_event_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_cron(test_tags, test_id):
     try:
         deployed_cron_flow = (
@@ -80,6 +82,7 @@ def test_cron(test_tags, test_id):
         deployed_cron_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_base_params(test_tags):
     try:
         deployed_flow = (

--- a/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
+++ b/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
@@ -11,6 +11,7 @@ def test_tags(test_id):
     return ["argo_workflows_tests", test_id]
 
 
+@pytest.mark.argo_workflows
 def test_argo_helloflow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")
@@ -27,6 +28,7 @@ def test_argo_helloflow(test_tags, test_id):
         deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_argo_conda_flow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"), environment="conda"
@@ -43,6 +45,7 @@ def test_argo_conda_flow(test_tags, test_id):
         deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_argo_pypi_flow(test_tags, test_id):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "pypitest.py"), environment="pypi"
@@ -59,6 +62,7 @@ def test_argo_pypi_flow(test_tags, test_id):
         deployed_flow.delete()
 
 
+@pytest.mark.argo_workflows
 def test_argo_notifications(test_tags):
     deployer = Deployer(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")

--- a/src/metaflow_qa_tests/basic/conftest.py
+++ b/src/metaflow_qa_tests/basic/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark = pytest.mark.local

--- a/src/metaflow_qa_tests/basic/test_basic.py
+++ b/src/metaflow_qa_tests/basic/test_basic.py
@@ -10,6 +10,7 @@ def test_tags(test_id):
     return ["basic_tests", test_id]
 
 
+@pytest.mark.local
 def test_helloflow(test_tags):
     result = Runner(flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")).run(
         tags=test_tags
@@ -18,6 +19,7 @@ def test_helloflow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.local
 def test_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"), environment="conda"
@@ -26,6 +28,7 @@ def test_conda_flow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.local
 def test_pypi_flow(test_tags):
     # Should default to fast-env
     result = Runner(

--- a/src/metaflow_qa_tests/flows/pypitest.py
+++ b/src/metaflow_qa_tests/flows/pypitest.py
@@ -1,7 +1,7 @@
 from metaflow import FlowSpec, step, pypi_base
 
 
-@pypi_base(packages={"pandas": "1.5.2"}, python="3.11")
+@pypi_base(packages={"pandas": "2.2.3", "numpy": "1.26.4"}, python="3.11")
 class PyPIFlow(FlowSpec):
     @step
     def start(self):

--- a/src/metaflow_qa_tests/kubernetes/conftest.py
+++ b/src/metaflow_qa_tests/kubernetes/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark = pytest.mark.kubernetes

--- a/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
+++ b/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
@@ -10,6 +10,7 @@ def test_tags(test_id):
     return ["kubernetes_tests", test_id]
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_helloflow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py"), decospecs=["kubernetes"]
@@ -18,6 +19,7 @@ def test_kubernetes_helloflow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"),
@@ -28,6 +30,7 @@ def test_kubernetes_conda_flow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_pypi_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "pypitest.py"),


### PR DESCRIPTION
## Summary
This PR implemented pytest markers for local, kubernetes, argo_workflows tests and added `conftest.py` to each subdirectories for fallback. It also resolves the mismatch `pandas` version inside `metaflow_qa_tests/flows/pypitest.py`.

## Context
This is a starter task for Metaflow CI/CD Integration: Issue #2 

## Changes Made
- Added `[tool.pytest.ini_options]` to `pyproject.toml`
- Added `@pytest.mark.local` to the 3 tests in `basic/test_basic.py`
- Added `@pytest.mark.kubernetes` to the 3 tests in `kubernetes/test_kubernetes.py`
- Added `@pytest.mark.argo_workflows` to all tests across `argo_workflows/`
- Added `conftest.py` files in `basic/`, `argo_workflows/`, `kubernetes/`

## Fix
- Update `pandas` plugin in `metaflow_qa_tests/flows/pypitest.py`
```
@pypi_base(packages={"pandas": "2.2.3", "numpy": "1.26.4"}, python="3.11")
```

## Testing proof
`pytest -m local` - selected and run 3 tests
<img width="1348" height="289" alt="image" src="https://github.com/user-attachments/assets/caee9d49-6cfe-4e0e-b95e-166496ced40e" />


`pytest -m local --collect-only` - selected 3 tests
<img width="1350" height="289" alt="image" src="https://github.com/user-attachments/assets/d3bce665-dfba-4cf8-9052-d22d4fbf4afe" />

`pytest -m kubernetes --collect-only` - selected 3 tests
<img width="962" height="291" alt="image" src="https://github.com/user-attachments/assets/cca7f94f-4f0b-4e1d-bea8-5eaf3a9a3319" />

 `pytest -m argo_workflows --collect-only` - selected 31 tests
<img width="1012" height="627" alt="image" src="https://github.com/user-attachments/assets/106d9112-f96a-4d81-8559-550e39d0c5c2" />

## Notes
- No `PytestUnknownMarkWarning` warning
- There is a `DeprecationWarning` in metaflow main repo (not related but worth noticing if `Python v3.14+` needed in the future)