### PR TITLE
design: add feature-level marker taxonomy with skip logic

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,10 @@
 import pytest
 import uuid
+import os
+import shutil
+
 
 # Add pytest helpers
-
-
 def pytest_addoption(parser):
     parser.addoption(
         "--test-id",
@@ -16,13 +17,74 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="session")
 def test_id(request):
     test_id = request.config.getoption("--test-id")
-
     if test_id is not None:
         return test_id
-
     # check for pytest-xdist availability
     if hasattr(request.config, "workerinput"):
         testrunid = request.config.workerinput["testrunuid"]
         return testrunid[:8]
-
     return uuid.uuid4().hex[:8]
+
+
+def pytest_collection_modifyitems(items):
+    """
+    Automatically infer feature markers from test names and
+    apply skip logic based on available infrastructure and tools.
+    
+    Backend markers (local, kubernetes, argo_workflows) are already
+    inferred from directory structure via conftest.py pytestmark.
+    
+    Feature markers are inferred from test names:
+    - "conda" in name → @pytest.mark.conda
+    - "pypi" in name → @pytest.mark.pypi
+    - "notification" in name → @pytest.mark.notifications
+    - "conditional" in name → @pytest.mark.conditionals
+    - "cron" in name → @pytest.mark.cron
+    - "param" or "base_params" in name → @pytest.mark.parameters
+    
+    Triggers marker must be explicit (test_events doesn't contain "trigger").
+    """
+    for item in items:
+        # ── Feature marker inference from test name ──────────────────
+        name = item.name.lower()
+
+        if "conda" in name:
+            item.add_marker(pytest.mark.conda)
+        if "pypi" in name:
+            item.add_marker(pytest.mark.pypi)
+        if "notification" in name:
+            item.add_marker(pytest.mark.notifications)
+        if "conditional" in name:
+            item.add_marker(pytest.mark.conditionals)
+        if "cron" in name:
+            item.add_marker(pytest.mark.cron)
+        if "param" in name or "base_params" in name:
+            item.add_marker(pytest.mark.parameters)
+
+        # ── Skip logic ───────────────────────────────────────────────
+
+        # Infrastructure checks
+        if "kubernetes" in item.keywords:
+            if not os.environ.get("METAFLOW_KUBERNETES_NAMESPACE"):
+                item.add_marker(pytest.mark.skip(
+                    reason="Kubernetes unavailable: METAFLOW_KUBERNETES_NAMESPACE not set"
+                ))
+
+        if "argo_workflows" in item.keywords:
+            if not os.environ.get("METAFLOW_ARGO_EVENTS_WEBHOOK_URL"):
+                item.add_marker(pytest.mark.skip(
+                    reason="Argo unavailable: METAFLOW_ARGO_EVENTS_WEBHOOK_URL not set"
+                ))
+
+        # Tool checks
+        if "conda" in item.keywords:
+            if not shutil.which("conda") and not shutil.which("micromamba"):
+                item.add_marker(pytest.mark.skip(
+                    reason="conda/micromamba not installed"
+                ))
+
+        if "pypi" in item.keywords:
+            if not shutil.which("pip"):
+                item.add_marker(pytest.mark.skip(
+                    reason="pip not available"
+                ))

--- a/docs/marker-taxonomy.md
+++ b/docs/marker-taxonomy.md
@@ -1,0 +1,113 @@
+# Marker Taxonomy for Feature-Level Test Selection
+
+## Overview
+
+Issue #2 added backend markers (`local`, `kubernetes`, `argo_workflows`) 
+so you can run tests by where they execute. But some tests also exercise 
+specific features like conda environments or Argo triggers. This document 
+proposes a second dimension of markers for these features.
+
+The key idea: **two independent dimensions**.
+
+- **Backend marker** — answers "where does this test run?"
+- **Feature marker** — answers "what does this test exercise?"
+
+A test like `test_kubernetes_conda_flow` gets BOTH `kubernetes` AND `conda`.
+They are orthogonal — neither implies the other. This lets you filter by
+either dimension independently:
+```bash
+pytest -m kubernetes          # all kubernetes tests
+pytest -m conda               # all conda tests across all backends
+pytest -m "kubernetes and conda"  # only kubernetes conda tests
+```
+
+## Backend Markers
+
+Backend markers are inferred automatically from directory structure via
+`conftest.py pytestmark` — no manual annotation needed on individual tests.
+
+| Marker | Description | How applied |
+|--------|-------------|-------------|
+| `local` | Runs against local backend via Runner API. No infrastructure needed. | `basic/conftest.py` pytestmark |
+| `kubernetes` | Steps run as Kubernetes pods via Runner API with `decospecs=["kubernetes"]` | `kubernetes/conftest.py` pytestmark |
+| `argo_workflows` | Flows deployed and triggered via Deployer API on Argo Workflows | `argo_workflows/conftest.py` pytestmark |
+
+## Feature Markers
+
+Feature markers describe WHAT a test exercises, independent of which
+backend it runs on. Most are inferred automatically from test names.
+The exception is `triggers` — `test_events` doesn't contain "trigger"
+in its name so it needs explicit annotation.
+
+| Marker | Description | How applied |
+|--------|-------------|-------------|
+| `conda` | Test uses `@conda_base` decorator. Requires conda or micromamba installed. | inferred from test name containing "conda" |
+| `pypi` | Test uses `@pypi_base` decorator. Requires pypi environment support. | inferred from test name containing "pypi" |
+| `conditionals` | Test exercises conditional branching flows. | inferred from test name containing "conditional" |
+| `triggers` | Test deploys flows with `@trigger` or `@trigger_on_finish` and fires events. | explicit annotation (see note above) |
+| `parameters` | Test exercises parameter passing and trigger-on-finish deployments. | inferred from test name containing "param" |
+| `cron` | Test deploys flows with cron-based scheduling. | inferred from test name containing "cron" |
+| `notifications` | Test verifies Argo Workflows notification configuration. | inferred from test name containing "notification" |
+
+## Complete Test Marker Table
+
+Every test mapped to its backend and feature markers:
+
+| Test | Backend | Feature |
+|------|---------|---------|
+| `test_helloflow` | `local` | — |
+| `test_conda_flow` | `local` | `conda` |
+| `test_pypi_flow` | `local` | `pypi` |
+| `test_kubernetes_helloflow` | `kubernetes` | — |
+| `test_kubernetes_conda_flow` | `kubernetes` | `conda` |
+| `test_kubernetes_pypi_flow` | `kubernetes` | `pypi` |
+| `test_argo_helloflow` | `argo_workflows` | — |
+| `test_argo_conda_flow` | `argo_workflows` | `conda` |
+| `test_argo_pypi_flow` | `argo_workflows` | `pypi` |
+| `test_argo_notifications` | `argo_workflows` | `notifications` |
+| `test_conditional_flows` | `argo_workflows` | `conditionals` |
+| `test_failing_conditional_flows` | `argo_workflows` | `conditionals` |
+| `test_successful_trigger_deployments` | `argo_workflows` | `triggers` |
+| `test_successful_trigger_on_finish_deployments` | `argo_workflows` | `triggers` |
+| `test_expected_failing_trigger_deployments` | `argo_workflows` | `triggers` |
+| `test_events` | `argo_workflows` | `triggers` |
+| `test_cron` | `argo_workflows` | `cron` |
+| `test_base_params` | `argo_workflows` | `parameters` |
+
+## Skip Logic
+
+A single `pytest_collection_modifyitems` hook in root `conftest.py`
+handles all skip conditions automatically. When a test has multiple
+markers (e.g. `kubernetes` AND `conda`), it skips if EITHER condition
+is not met — no per-test skip decorators needed.
+
+**Infrastructure checks (environment variables):**
+- `kubernetes` → skip if `METAFLOW_KUBERNETES_NAMESPACE` not set
+- `argo_workflows` → skip if `METAFLOW_ARGO_EVENTS_WEBHOOK_URL` not set
+
+**Tool checks (shutil.which):**
+- `conda` → skip if neither `conda` nor `micromamba` found
+- `pypi` → skip if `pip` not found
+
+This gives clean skip messages instead of confusing failures:
+```
+SKIPPED test_conda_flow — conda/micromamba not installed
+SKIPPED test_kubernetes_conda_flow — Kubernetes unavailable
+```
+
+## Tox Integration
+
+No new tox environments needed. Feature markers compose cleanly with
+the existing three backend environments using `--` to pass pytest flags:
+```bash
+tox -e local                          # all local tests
+tox -e local -- -m conda              # local conda tests only
+tox -e kubernetes -- -m conda         # kubernetes conda tests only
+tox -e argo -- -m triggers            # argo trigger tests only
+tox -e argo -- -m conditionals        # argo conditional tests only
+tox -e argo -- -m "not conditionals"  # argo tests excluding conditionals
+```
+
+Adding `tox -e local-conda` would mean 3 backends × 7 features = 21
+potential environments. Marker flags achieve the same result with
+zero extra maintenance.

--- a/docs/marker-taxonomy.md
+++ b/docs/marker-taxonomy.md
@@ -111,3 +111,21 @@ tox -e argo -- -m "not conditionals"  # argo tests excluding conditionals
 Adding `tox -e local-conda` would mean 3 backends × 7 features = 21
 potential environments. Marker flags achieve the same result with
 zero extra maintenance.
+## Trade-offs: orthogonal vs hierarchical markers
+
+**Hierarchical** means feature markers imply backend markers —
+`@pytest.mark.triggers` would automatically imply `@pytest.mark.argo_workflows`.
+This reduces annotation: one marker instead of two.
+
+The problem: the implication breaks the moment a second backend supports the
+same feature. If Maestro trigger tests are added later, `triggers` can no longer
+imply `argo_workflows` without excluding them. Every test using `triggers` would
+need to be re-annotated.
+
+**Orthogonal** means markers are independent — `triggers` says nothing about
+which backend. It requires two markers per test but the taxonomy stays stable as
+new backends are added. `pytest -m "triggers and argo_workflows"` and
+`pytest -m "triggers and maestro"` both work without changing any existing tests.
+
+Given the README explicitly mentions Maestro as a future orchestrator, orthogonal
+is the right choice here. The small annotation overhead is worth the extensibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,20 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+markers = [
+    # Backend markers (where the test runs)
+    "local: runs against local backend via Runner API",
+    "kubernetes: runs steps as Kubernetes pods via Runner API",
+    "argo_workflows: deploys and triggers flows via Deployer API on Argo",
+
+    # Feature markers (what the test exercises)
+    "conda: requires conda or micromamba to be installed",
+    "pypi: requires pypi environment support",
+    "triggers: tests deploy-time trigger and event functionality",
+    "conditionals: tests conditional branching flows",
+    "parameters: tests parameter passing and trigger-on-finish",
+    "cron: tests cron-based scheduling",
+    "notifications: tests Argo workflow notification config",
+]

--- a/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
+++ b/src/metaflow_qa_tests/argo_workflows/conditional_tests/test_conditionals.py
@@ -7,6 +7,7 @@ from ..utils import (
 import io
 import os
 
+pytestmark = pytest.mark.argo_workflows
 
 ROOT = os.path.dirname(__file__)
 

--- a/src/metaflow_qa_tests/argo_workflows/conftest.py
+++ b/src/metaflow_qa_tests/argo_workflows/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark = pytest.mark.argo_workflows

--- a/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
+++ b/src/metaflow_qa_tests/argo_workflows/deploy_time_triggers/test_deploy_time_triggers.py
@@ -4,6 +4,8 @@ from contextlib import redirect_stdout
 import io
 import os
 
+pytestmark = pytest.mark.argo_workflows
+
 ROOT = os.path.dirname(__file__)
 
 # TODO: Test the actual triggered behaviour as well. Omitted for now, as the deployment should be enough of a verification for this functionality.
@@ -14,6 +16,7 @@ def test_tags(test_id):
     return ["argo_workflows_tests", "deploy_time_triggers_tests", test_id]
 
 
+@pytest.mark.triggers
 def test_successful_trigger_deployments(test_tags):
     # "filename, expected_trigger",
     filename_and_trigger = [
@@ -48,6 +51,7 @@ def test_successful_trigger_deployments(test_tags):
             deployer.delete()
 
 
+@pytest.mark.triggers
 def test_successful_trigger_on_finish_deployments(test_tags):
     # "filename, expected_trigger"
     filename_and_trigger = [
@@ -88,6 +92,7 @@ def test_successful_trigger_on_finish_deployments(test_tags):
             deployer.delete()
 
 
+@pytest.mark.triggers
 def test_expected_failing_trigger_deployments(test_tags):
     # "filename",
     filenames = [

--- a/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
+++ b/src/metaflow_qa_tests/argo_workflows/parameter_tests/test_parameters.py
@@ -9,6 +9,8 @@ from ..utils import (
 )
 import os
 
+pytestmark = pytest.mark.argo_workflows
+
 ROOTPATH = os.path.dirname(__file__)
 
 
@@ -20,6 +22,7 @@ def test_tags(test_id):
 # TODO: Add coverage for dashed params and double-quoted strings!
 
 
+@pytest.mark.triggers
 def test_events(test_tags, test_id):
     try:
         deployed_event_flow = (

--- a/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
+++ b/src/metaflow_qa_tests/argo_workflows/test_argo_basic.py
@@ -3,6 +3,8 @@ from metaflow import Deployer
 from .utils import wait_for_run, wait_for_run_to_finish
 import os
 
+pytestmark = pytest.mark.argo_workflows
+
 FLOWS_ROOT = os.path.join(os.path.dirname(__file__), "..", "flows")
 
 

--- a/src/metaflow_qa_tests/basic/conftest.py
+++ b/src/metaflow_qa_tests/basic/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark = pytest.mark.local

--- a/src/metaflow_qa_tests/basic/test_basic.py
+++ b/src/metaflow_qa_tests/basic/test_basic.py
@@ -10,6 +10,7 @@ def test_tags(test_id):
     return ["basic_tests", test_id]
 
 
+@pytest.mark.local
 def test_helloflow(test_tags):
     result = Runner(flow_file=os.path.join(FLOWS_ROOT, "helloflow.py")).run(
         tags=test_tags
@@ -18,6 +19,7 @@ def test_helloflow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.local
 def test_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"), environment="conda"
@@ -26,6 +28,7 @@ def test_conda_flow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.local
 def test_pypi_flow(test_tags):
     # Should default to fast-env
     result = Runner(

--- a/src/metaflow_qa_tests/kubernetes/conftest.py
+++ b/src/metaflow_qa_tests/kubernetes/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark = pytest.mark.kubernetes

--- a/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
+++ b/src/metaflow_qa_tests/kubernetes/test_kubernetes.py
@@ -10,6 +10,7 @@ def test_tags(test_id):
     return ["kubernetes_tests", test_id]
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_helloflow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "helloflow.py"), decospecs=["kubernetes"]
@@ -18,6 +19,7 @@ def test_kubernetes_helloflow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_conda_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "condatest.py"),
@@ -28,6 +30,7 @@ def test_kubernetes_conda_flow(test_tags):
     assert result.run.finished
 
 
+@pytest.mark.kubernetes
 def test_kubernetes_pypi_flow(test_tags):
     result = Runner(
         flow_file=os.path.join(FLOWS_ROOT, "pypitest.py"),


### PR DESCRIPTION
closes #9
Depends on #2

Note: includes #2 changes since it's not yet merged. new work for this PR is conftest.py, pyproject.toml, docs/marker-taxonomy.md, and explicit triggers markers on 2 files.

## Summary

Adds feature-level markers as a second dimension alongside the backend markers from #2. A test like test_kubernetes_conda_flow now has both kubernetes AND conda markers — independent of each other. Full design is in docs/marker-taxonomy.md.

This PR delivers both the design document AND a working implementation — markers are inferred automatically, skip logic 
is live, and everything is verified below.

## Design Decisions

**Should test_kubernetes_conda_flow have both markers?**
Yes. pytest -m kubernetes selecting it is correct — anyone running kubernetes tests wants all of them. Skip logic handles the case where conda isn't installed.

**Should triggers imply argo_workflows?**
No — kept orthogonal. The README mentions Maestro as an alternate orchestrator. Hard-wiring that now breaks the moment Maestro trigger tests get added.

**How to handle combinatorial skip logic?**
Single pytest_collection_modifyitems hook in root conftest.py handles everything. Infrastructure checked via env vars, tools 
via shutil.which(). test_kubernetes_conda_flow skips if EITHER condition fails — no per-test decorators needed.

**Explicit annotation vs name inference?**
Hybrid — backend markers from directory structure, feature markers inferred from test names automatically. Only exception is triggers since test_events doesn't contain "trigger" in its name.

**New tox environments for features?**
No. tox -e local -- -m conda does the job. 3 backends × 7 features = 21 environments otherwise — overkill.

## Verification

<img width="1584" height="388" alt="Screenshot 2026-03-16 125352" src="https://github.com/user-attachments/assets/59df7706-c94b-45a0-b6c8-ac73aa663dd0" />

pytest -m conda → 3/37 selected ✅
pytest -m "kubernetes and conda" → 1/37 selected ✅
pytest -m triggers → 4/37 selected ✅