### PR TITLE
feat: add reference implementation for event-trigger lifecycle test

### DIFF
--- a/src/metaflow_qa_tests/argo_workflows/test_simple_trigger.py
+++ b/src/metaflow_qa_tests/argo_workflows/test_simple_trigger.py
@@ -1,0 +1,142 @@
+"""
+Reference implementation: full deploy → trigger → wait → assert → cleanup.
+
+This file is intentionally over-commented. It serves two purposes:
+  1. A working test that verifies the event-trigger lifecycle end to end
+  2. A guide for anyone adding support for a new orchestrator backend
+
+The only backend-specific line in the test body is the Deployer call.
+Everything else — the flow, the wait utilities, the assertions — is
+backend-agnostic.
+
+To port to a different orchestrator, change only get_deployer():
+    Argo Workflows:      Deployer(...).argo_workflows()
+    Step Functions:      Deployer(...).step_functions()
+    (future) Maestro:    Deployer(...).maestro()
+
+Answers to the three open design questions from issue #6:
+
+Q: Should the backend be parameterized via fixture, CLI option, or env var?
+A: Environment variable read inside a fixture. This keeps the test body
+   clean (no backend logic), works with tox without extra config, and
+   lets CI override the backend without changing any test code.
+
+Q: How do you structure the test so adding Maestro only changes the Deployer call?
+A: The get_deployer fixture encapsulates the backend choice entirely.
+   The test calls get_deployer(flow_file) and gets back a deployer object.
+   It never calls .argo_workflows() directly. Adding Maestro = one elif
+   clause in the fixture, zero changes to any test.
+
+Q: Should the trigger flow be a new file or reuse an existing one?
+A: New file (trigger_flow.py). The existing flows in deploy_time_triggers/
+   only verify deployment — they do not trigger, wait, and assert a
+   completed run. A dedicated minimal flow makes the test self-contained
+   and easy to understand in isolation.
+"""
+import os
+import pytest
+from metaflow import Deployer
+from .utils import wait_for_run, wait_for_run_to_finish
+
+FLOWS_ROOT = os.path.join(os.path.dirname(__file__), "..", "flows")
+
+EVENT_NAME = "test_event"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def test_tags(test_id):
+    return ["argo_workflows_tests", "trigger_tests", test_id]
+
+
+@pytest.fixture
+def get_deployer():
+    """
+    Returns a factory function that creates the right Deployer backend.
+
+    Reads METAFLOW_TEST_BACKEND env var (default: argo_workflows).
+    This is the only place the backend name appears — changing backends
+    requires zero changes to test logic.
+
+    Supported values:
+        argo_workflows  →  .argo_workflows()
+        step_functions  →  .step_functions()
+    """
+    backend = os.environ.get("METAFLOW_TEST_BACKEND", "argo_workflows")
+
+    def _make(flow_file):
+        d = Deployer(flow_file=flow_file)
+        if backend == "argo_workflows":
+            return d.argo_workflows()
+        elif backend == "step_functions":
+            return d.step_functions()
+        else:
+            raise ValueError(
+                f"Unknown METAFLOW_TEST_BACKEND='{backend}'. "
+                "Supported: 'argo_workflows', 'step_functions'."
+            )
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.argo_workflows
+def test_simple_event_trigger(test_tags, test_id, get_deployer):
+    """
+    Full lifecycle test: deploy a flow, fire an event, verify the run succeeds.
+
+    Lifecycle phases:
+        1. DEPLOY  — register TriggerFlow with the orchestrator
+        2. TRIGGER — fire a trigger with a parameter value
+        3. WAIT    — poll until the triggered run appears and finishes
+        4. ASSERT  — verify run succeeded and parameter arrived correctly
+        5. CLEANUP — delete the deployment (always runs, even on failure)
+    """
+    # Phase 1 — DEPLOY
+    # Compiles TriggerFlow and registers it with the orchestrator.
+    # After this step the flow is live and listening for "test_event".
+    deployed_flow = get_deployer(
+        os.path.join(FLOWS_ROOT, "trigger_flow.py")
+    ).create(tags=test_tags)
+
+    try:
+        # Phase 2 — TRIGGER
+        # Fires a trigger with param_a and returns a TriggeredRun object.
+        # The event name is registered on the flow via @trigger(event=EVENT_NAME).
+        # Passing param_a here lets us assert the value arrived correctly.
+        deployed_flow.trigger(param_a="hello from trigger")
+
+        # Phase 3 — WAIT for a new run to appear
+        # Polls Flow(flow_name).latest_run until a run newer than now
+        # appears in the test_id namespace. Timeout: 120s.
+        run = wait_for_run(deployed_flow.flow_name, ns=test_id, timeout=120)
+
+        # Phase 4 — WAIT for the run to finish
+        # Polls run.finished_at until complete. Re-raises any exception
+        # stored in run.data.test_failure by @catch in TriggerFlow.start.
+        run = wait_for_run_to_finish(run, timeout=240)
+
+        # Phase 5 — ASSERT
+        # run.successful is True only when all steps exit with code 0.
+        assert run.successful, (
+            f"TriggerFlow run did not succeed. "
+            "Check the run logs for details."
+        )
+        # Verify the parameter value was passed through trigger() correctly.
+        assert run.data.param_a == "hello from trigger", (
+            f"Expected param_a='hello from trigger', "
+            f"got '{run.data.param_a}'"
+        )
+
+    finally:
+        # Phase 5 — CLEANUP
+        # Deletes the deployed workflow template from the orchestrator.
+        # Runs even if any phase above raises — prevents orphaned
+        # deployments accumulating across test runs.
+        deployed_flow.delete()

--- a/src/metaflow_qa_tests/flows/trigger_flow.py
+++ b/src/metaflow_qa_tests/flows/trigger_flow.py
@@ -1,0 +1,41 @@
+"""
+Minimal flow for the event-trigger reference test (issue #6).
+
+Kept intentionally simple: start → end, one parameter, @catch for
+error surfacing. The only purpose is to verify the full trigger lifecycle:
+deploy → event fires → run starts → parameter arrives → run completes.
+
+BACKEND-AGNOSTIC: no Argo, Maestro, or Step Functions imports.
+Works with any orchestrator that supports @trigger.
+"""
+from metaflow import FlowSpec, step, current, trigger, catch, Parameter
+
+EVENT_NAME = "test_event"
+
+
+@trigger(event=EVENT_NAME)
+class TriggerFlow(FlowSpec):
+
+    param_a = Parameter(
+        name="param_a",
+        default="default value A",
+        type=str,
+    )
+
+    @catch(var="test_failure")
+    @step
+    def start(self):
+        print(f"TriggerFlow started — run id: {current.run_id}")
+        print(f"param_a = {self.param_a}")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        test_failure = getattr(self, "test_failure", None)
+        if test_failure is not None:
+            raise test_failure
+        print("TriggerFlow complete.")
+
+
+if __name__ == "__main__":
+    TriggerFlow()


### PR DESCRIPTION
Fixes #6
Depends on #2, #3

**What this adds**
A single, heavily-commented reference test for the full deploy → trigger → wait → assert → cleanup lifecycle. The existing tests in deploy_time_triggers/ and parameter_tests/ are complex and undocumented — this is the example any developer can read once and follow.

Two files added:
src/metaflow_qa_tests/flows/trigger_flow.py — minimal @trigger flow with one parameter and @catch for clean error surfacing
src/metaflow_qa_tests/argo_workflows/test_simple_trigger.py — reference test, every phase commented, backend fully parameterized

**Design decisions**
**Backend via env var fixture** — get_deployer() reads METAFLOW_TEST_BACKEND (default: argo_workflows). Test body never calls .argo_workflows() directly. Adding Maestro = one elif in the fixture, zero test changes. Better than CLI option — works with tox without extra config, no workflow file changes needed in CI.
**wait_for_run + wait_for_run_to_finish** — used exactly as specified, with ns=test_id to isolate concurrent runs.
@catch(var="test_failure") — follows parameter_tests/eventflow.py pattern. Errors surface immediately rather than timing out.
**New file in flows/** — existing flows only verify deployment, not the full lifecycle. Placed alongside other reusable flows.
Works with previous issues

#2 — markers registered, no PytestUnknownMarkWarning ✅
#3 — tox -e argo runs this test correctly once merged ✅
#5 — test runs automatically in CI once merged ✅

**Verification**
Tested inside metaflow-dev shell on top of #2 and #3 — 1 passed, 1 warning in 143.30s:
<img width="1910" height="795" alt="image" src="https://github.com/user-attachments/assets/94db70e7-7d20-4ef9-a943-fe0932c705ba" />
