### PR TITLE
design: add extension testing framework with prototype implementation

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,12 @@ def pytest_addoption(parser):
         default=None,
         help="A unique ID for this test run. One will be generated if not provided",
     )
+    parser.addoption(
+        "--extension",
+        action="append",
+        default=[],
+        help="Path to a Metaflow extension to load. Can be repeated for multiple extensions.",
+    )
 
 
 @pytest.fixture(scope="session")
@@ -26,3 +32,46 @@ def test_id(request):
         return testrunid[:8]
 
     return uuid.uuid4().hex[:8]
+
+
+def pytest_configure(config):
+    """
+    Handle --extension flags by:
+    1. Prepending extension paths to sys.path (PYTHONPATH approach from Netflix's run_tests.py line 204)
+    2. Setting METAFLOW_EXTENSIONS_SEARCH_DIRS for scoped discovery (from extension_support/__init__.py)
+    3. Adding extension test directories to pytest discovery
+    """
+    import os
+    import sys
+    from pathlib import Path
+
+    extensions = config.getoption("--extension", default=[])
+    if not extensions:
+        return
+
+    search_dirs = []
+
+    for ext_path in extensions:
+        ext_path = Path(ext_path).resolve()
+        if not ext_path.exists():
+            raise ValueError(f"Extension path does not exist: {ext_path}")
+
+        # PYTHONPATH approach — prepend to sys.path
+        # Same pattern used in Netflix/metaflow/test/core/run_tests.py line 204
+        sys.path.insert(0, str(ext_path))
+        search_dirs.append(str(ext_path))
+
+        # Add extension tests to discovery
+        # Convention: metaflow_extensions/<org>/tests/
+        ext_ns = ext_path / "metaflow_extensions"
+        if ext_ns.exists():
+            for org_dir in ext_ns.iterdir():
+                if org_dir.is_dir() and not org_dir.name.startswith("_"):
+                    tests_dir = org_dir / "tests"
+                    if tests_dir.exists():
+                        sys.path.insert(0, str(tests_dir))
+                        config.args.append(str(tests_dir))
+
+    # Scope Metaflow extension discovery to specified dirs only
+    # Prevents extension A from affecting extension B's run
+    os.environ["METAFLOW_EXTENSIONS_SEARCH_DIRS"] = os.pathsep.join(search_dirs)

--- a/docs/extension-testing-framework.md
+++ b/docs/extension-testing-framework.md
@@ -1,0 +1,132 @@
+# Extension Testing Framework
+
+## Problem
+
+The QA test suite has no way to:
+- Run with a custom extension installed to check for regressions
+- Run extension-specific tests alongside core tests
+- Test combinations of extensions together
+
+## Design
+
+### CLI Interface
+
+```bash
+# Test core with one extension
+tox -e local -- --extension ./path/to/my-extension
+
+# Test with multiple extensions
+tox -e local -- --extension ./ext-a --extension ./ext-b
+
+# Extension's own tests are discovered automatically
+tox -e local -- --extension ./ext-a
+```
+
+### Dynamic Installation
+
+Two modes based on Netflix's own patterns:
+
+**Local/unpublished extensions — PYTHONPATH approach**
+
+Based on `Netflix/metaflow/test/core/run_tests.py` line 204,
+extensions are loaded by prepending the path to `sys.path`.
+No pip install needed — works for local and unpublished extensions.
+
+**Published extensions — tox deps**
+
+```ini
+[testenv:local-myext]
+deps = my-published-extension
+```
+
+### How --extension Works
+
+When `--extension ./my-ext` is passed, `pytest_configure` in
+root `conftest.py`:
+
+1. Prepends `./my-ext` to `sys.path` — Python finds the extension
+2. Sets `METAFLOW_EXTENSIONS_SEARCH_DIRS=./my-ext` — scopes
+   Metaflow's discovery to that directory only
+3. Scans `./my-ext/metaflow_extensions/<org>/tests/` and adds
+   to pytest's path for automatic test discovery
+
+### Test Discovery Convention
+
+Extensions place pytest tests at:
+
+```
+metaflow_extensions/<org>/tests/
+```
+
+This matches the namespace package structure from the
+[extensions template](https://github.com/Netflix/metaflow-extensions-template).
+`conftest.py` scans for this directory automatically.
+
+### Backend x Extension Matrix
+
+For known CI combinations — tox factors:
+
+```ini
+[tox]
+envlist = local, kubernetes, argo, local-{ext_a,ext_b}
+
+[testenv:local-{ext_a,ext_b}]
+deps =
+    ext_a: ./tests/extensions/ext_a
+    ext_b: ./tests/extensions/ext_b
+commands = pytest -m local --pyargs metaflow_qa_tests -v {posargs}
+```
+
+For ad-hoc local testing — use `--extension` flag without
+creating new environments.
+
+### Isolation Guarantees
+
+**What's safe:**
+
+- `METAFLOW_EXTENSIONS_SEARCH_DIRS` scopes discovery per invocation
+- Tox creates fresh virtualenvs per factor — extension A can't
+  affect extension B's tox factor run
+- `METAFLOW_DEBUG_EXT=1` shows extension load order for debugging
+
+**What can go wrong:**
+
+- Extensions modify global state at import time
+- If two extensions override the same decorator, last one wins
+- Within a single pytest session, extensions accumulate — use
+  separate tox invocations for true isolation
+
+### Override Behavior Testing
+
+```bash
+METAFLOW_DEBUG_EXT=1 tox -e local -- --extension ./ext-a --extension ./ext-b
+```
+
+Debug output shows load order. Assert that later-loaded extension
+behavior takes precedence.
+
+## Prototype
+
+`tests/extensions/sample_extension/` is a minimal working example.
+
+Run it with:
+
+```bash
+tox -e local -- --extension tests/extensions/sample_extension
+```
+
+Expected output:
+
+```
+test_sample_extension.py::test_extension_loaded PASSED
+test_sample_extension.py::test_extension_search_dirs PASSED
+```
+
+## Trade-offs
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| PYTHONPATH (chosen for local) | No pip install, fast | Requires namespace convention |
+| pip install | Works with any package | Slower, needs published package |
+| tox factors (chosen for CI) | Best isolation | New env per combination |
+| --extension flag | Flexible, no new envs | Less isolation within session |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,11 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers"
+markers = [
+    "local: tests that run against the local backend (no infrastructure)",
+    "kubernetes: tests that run steps on Kubernetes (requires dev stack)",
+    "argo_workflows: tests that deploy to Argo Workflows (requires dev stack + Argo)",
+]

--- a/tests/extensions/sample_extension/metaflow_extensions/sample/mfextinit_sample.py
+++ b/tests/extensions/sample_extension/metaflow_extensions/sample/mfextinit_sample.py
@@ -1,0 +1,6 @@
+# Minimal Metaflow extension — demonstrates the namespace package
+# structure required by Metaflow's extension system.
+#
+# File naming convention: mfextinit_<org>.py
+# This replaces __init__.py for namespace packages.
+# See: metaflow/extension_support/__init__.py

--- a/tests/extensions/sample_extension/metaflow_extensions/sample/tests/test_sample_extension.py
+++ b/tests/extensions/sample_extension/metaflow_extensions/sample/tests/test_sample_extension.py
@@ -1,0 +1,39 @@
+"""
+Sample extension tests — discovered automatically when running:
+    tox -e local -- --extension tests/extensions/sample_extension
+
+These tests demonstrate that:
+1. The extension is loadable via sys.path (PYTHONPATH approach)
+2. METAFLOW_EXTENSIONS_SEARCH_DIRS is scoped correctly
+3. Extension tests are discovered alongside core tests
+"""
+import os
+import pytest
+
+
+@pytest.mark.local
+def test_extension_loaded():
+    """
+    Verify that the sample extension directory is on sys.path.
+    The --extension flag prepends the path via pytest_configure in conftest.py.
+    """
+    import sys
+    # At least one path containing 'sample_extension' should be in sys.path
+    ext_paths = [p for p in sys.path if "sample_extension" in p]
+    assert len(ext_paths) > 0, (
+        "sample_extension not found in sys.path. "
+        "Did you pass --extension tests/extensions/sample_extension?"
+    )
+
+
+@pytest.mark.local
+def test_extension_search_dirs():
+    """
+    Verify METAFLOW_EXTENSIONS_SEARCH_DIRS is set to scope
+    Metaflow's extension discovery to our extension only.
+    """
+    search_dirs = os.environ.get("METAFLOW_EXTENSIONS_SEARCH_DIRS", "")
+    assert "sample_extension" in search_dirs, (
+        "METAFLOW_EXTENSIONS_SEARCH_DIRS not set correctly. "
+        f"Got: '{search_dirs}'"
+    )

--- a/tests/extensions/sample_extension/setup.py
+++ b/tests/extensions/sample_extension/setup.py
@@ -1,0 +1,9 @@
+from setuptools import find_namespace_packages, setup
+
+setup(
+    name="metaflow-sample-extension",
+    version="0.1.0",
+    description="Minimal sample extension for testing the extension framework",
+    packages=find_namespace_packages(include=["metaflow_extensions.*"]),
+    zip_safe=False,
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,63 @@
+[tox]
+envlist = local, kubernetes, argo
+
+[testenv]
+usedevelop = true
+passenv =
+    # Core Metaflow config
+    METAFLOW_HOME
+    METAFLOW_PROFILE
+    METAFLOW_DEFAULT_METADATA
+    METAFLOW_SERVICE_URL
+    METAFLOW_SERVICE_INTERNAL_URL
+    METAFLOW_UI_URL
+    # Datastore / S3 / MinIO
+    METAFLOW_DEFAULT_DATASTORE
+    METAFLOW_DATASTORE_SYSROOT_S3
+    AWS_CONFIG_FILE
+    AWS_SHARED_CREDENTIALS_FILE
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
+    AWS_ENDPOINT_URL_S3
+    # Kubernetes
+    METAFLOW_KUBERNETES_NAMESPACE
+    METAFLOW_KUBERNETES_SECRETS
+    METAFLOW_KUBERNETES_JOBSET_ENABLED
+    METAFLOW_KUBERNETES_CONDA_ARCH
+    # Argo Events
+    METAFLOW_ARGO_EVENTS_EVENT
+    METAFLOW_ARGO_EVENTS_EVENT_BUS
+    METAFLOW_ARGO_EVENTS_EVENT_SOURCE
+    METAFLOW_ARGO_EVENTS_INTERNAL_WEBHOOK_URL
+    METAFLOW_ARGO_EVENTS_SERVICE_ACCOUNT
+    METAFLOW_ARGO_EVENTS_WEBHOOK_AUTH
+    METAFLOW_ARGO_EVENTS_WEBHOOK_URL
+    # System
+    HOME
+    USER
+    KUBECONFIG
+    METAFLOW_EXTENSIONS_SEARCH_DIRS
+    METAFLOW_DEBUG_EXT
+    PYTHONPATH
+
+[testenv:local]
+commands = pytest -m local --pyargs metaflow_qa_tests -v {posargs}
+
+[testenv:kubernetes]
+deps = kubernetes
+commands = pytest -m kubernetes --pyargs metaflow_qa_tests -v {posargs}
+
+[testenv:argo]
+deps = kubernetes
+commands = pytest -m argo_workflows --pyargs metaflow_qa_tests -v {posargs}
+
+[testenv:all]
+deps = kubernetes
+commands =
+    pytest -m local --pyargs metaflow_qa_tests -v {posargs}
+    pytest -m kubernetes --pyargs metaflow_qa_tests -v {posargs}
+    pytest -m argo_workflows --pyargs metaflow_qa_tests -v {posargs}
+
+[testenv:extension]
+deps = kubernetes
+commands = pytest --pyargs metaflow_qa_tests -v {posargs}


### PR DESCRIPTION
Closes #8
Depends on #2, #3

Note: includes pyproject.toml and tox.ini from #2 and #3 since neither is merged yet.

## What this adds

Design document + working prototype for plugging Metaflow extensions into the QA test suite. Full design is in docs/extension-testing-framework.md.

## How it works

A new --extension flag in conftest.py:

tox -e local -- --extension ./path/to/my-extension

This does three things:
1. Prepends extension path to sys.path — same pattern Netflix uses in run_tests.py (line 204), no pip install needed
2. Sets METAFLOW_EXTENSIONS_SEARCH_DIRS — scopes Metaflow's discovery to that extension only                                      (extension_support/__init__.py line 94)
3. Discovers tests from metaflow_extensions/<org>/tests/ — matches namespace package convention from extensions template

## Design decisions

Works with any tox env:
tox -e local -- --extension ./ext-a
tox -e kubernetes -- --extension ./ext-a

Multiple extensions:
tox -e local -- --extension ./ext-a --extension ./ext-b

## Prototype

tests/extensions/sample_extension/ is a minimal working example following the metaflow_extensions/<org>/ convention.

## Verification

tox -e local -- --extension tests/extensions/sample_extension --collect-only
<img width="1898" height="465" alt="Screenshot 2026-03-20 123955" src="https://github.com/user-attachments/assets/62c07651-111b-4262-ac80-84d3e3b52af4" />

tox -e local -- --extension tests/extensions/sample_extension --collect-only
<img width="1884" height="798" alt="image" src="https://github.com/user-attachments/assets/0f767421-b15a-43c2-aa03-491d23981720" />